### PR TITLE
RIA-1287 Allow respondent evidence to be added multiple times

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
@@ -20,6 +20,7 @@ public enum Event {
     UPLOAD_ADDITIONAL_EVIDENCE("uploadAdditionalEvidence"),
     LIST_CASE("listCase"),
     CREATE_CASE_SUMMARY("createCaseSummary"),
+    REVERT_STATE_TO_AWAITING_RESPONDENT_EVIDENCE("revertStateToAwaitingRespondentEvidence"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
@@ -24,11 +24,12 @@ public class EventTest {
         assertEquals("uploadAdditionalEvidence", Event.UPLOAD_ADDITIONAL_EVIDENCE.toString());
         assertEquals("listCase", Event.LIST_CASE.toString());
         assertEquals("createCaseSummary", Event.CREATE_CASE_SUMMARY.toString());
+        assertEquals("revertStateToAwaitingRespondentEvidence", Event.REVERT_STATE_TO_AWAITING_RESPONDENT_EVIDENCE.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(17, Event.values().length);
+        assertEquals(18, Event.values().length);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-1287

### Change description ###

Support for replaying the "Upload additional evidence" more than once

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
