### PR TITLE
Logging the response in full even when there is an error response.

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacasedocumentsapi/CcdScenarioRunnerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacasedocumentsapi/CcdScenarioRunnerTest.java
@@ -121,6 +121,7 @@ public class CcdScenarioRunnerTest {
                     .body(requestBody)
                     .when()
                     .post(requestUri)
+                    .peek()
                     .then()
                     .statusCode(expectedStatus)
                     .and()
@@ -132,8 +133,6 @@ public class CcdScenarioRunnerTest {
                 MapValueExtractor.extract(scenario, "expectation"),
                 templatesByFilename
             );
-
-            System.out.println("Actual Response: " + actualResponseBody);
 
             Map<String, Object> actualResponse = MapSerializer.deserialize(actualResponseBody);
             Map<String, Object> expectedResponse = MapSerializer.deserialize(expectedResponseBody);


### PR DESCRIPTION
Useful to see the full response if there's an error response in tests.