### PR TITLE
RIA-1359: Edit appeal after submit event created.

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-1359-edit-appeal-after-submission-document.json
+++ b/src/functionalTest/resources/scenarios/RIA-1359-edit-appeal-after-submission-document.json
@@ -1,0 +1,41 @@
+{
+  "description": "RIA-1359 Edit appeal after submission document",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "editAppealAfterSubmit",
+      "state": "awaitingRespondentEvidence",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "legalRepresentativeDocuments": []
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "legalRepresentativeDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-appeal-form.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "appealSubmission"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
@@ -32,6 +32,7 @@ public enum Event {
     ADJOURN_HEARING_WITHOUT_DATE("adjournHearingWithoutDate"),
     SUBMIT_CMA_REQUIREMENTS("submitCmaRequirements"),
     LIST_CMA("listCma"),
+    EDIT_APPEAL_AFTER_SUBMIT("editAppealAfterSubmit"),
 
     @JsonEnumDefaultValue
     UNKNOWN("unknown");

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/AppealSubmissionCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/AppealSubmissionCreator.java
@@ -39,7 +39,9 @@ public class AppealSubmissionCreator implements PreSubmitCallbackHandler<AsylumC
         requireNonNull(callback, "callback must not be null");
 
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-               && callback.getEvent() == Event.SUBMIT_APPEAL;
+            && callback.getEvent() == Event.SUBMIT_APPEAL
+            || callback.getEvent() == Event.EDIT_APPEAL_AFTER_SUBMIT
+            ;
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -172,6 +172,7 @@ security:
       - "endAppeal"
       - "updateHearingRequirements"
       - "adjournHearingWithoutDate"
+      - "editAppealAfterSubmit"
     caseworker-ia-admofficer:
       - "listCase"
       - "editCaseListing"

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
@@ -41,6 +41,6 @@ public class EventTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(28, Event.values().length);
+        assertEquals(29, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
@@ -35,6 +35,7 @@ public class EventTest {
         assertEquals("adjournHearingWithoutDate", Event.ADJOURN_HEARING_WITHOUT_DATE.toString());
         assertEquals("submitCmaRequirements", Event.SUBMIT_CMA_REQUIREMENTS.toString());
         assertEquals("listCma", Event.LIST_CMA.toString());
+        assertEquals("editAppealAfterSubmit", Event.EDIT_APPEAL_AFTER_SUBMIT.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/AppealSubmissionCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/AppealSubmissionCreatorTest.java
@@ -74,6 +74,19 @@ public class AppealSubmissionCreatorTest {
     }
 
     @Test
+    public void should_create_appeal_submission_pdf_and_append_to_legal_representative_documents_for_the_case_when_edit_appeal_after_submit() {
+        when(callback.getEvent()).thenReturn(Event.EDIT_APPEAL_AFTER_SUBMIT);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            appealSubmissionCreator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(documentHandler, times(1)).addWithMetadata(asylumCase, uploadedDocument, LEGAL_REPRESENTATIVE_DOCUMENTS, DocumentTag.APPEAL_SUBMISSION);
+    }
+
+    @Test
     public void handling_should_throw_if_cannot_actually_handle() {
 
         assertThatThrownBy(() -> appealSubmissionCreator.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
@@ -97,8 +110,9 @@ public class AppealSubmissionCreatorTest {
 
                 boolean canHandle = appealSubmissionCreator.canHandle(callbackStage, callback);
 
-                if (event == Event.SUBMIT_APPEAL
-                    && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT) {
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                    && event == Event.SUBMIT_APPEAL
+                    || event == Event.EDIT_APPEAL_AFTER_SUBMIT) {
 
                     assertTrue(canHandle);
                 } else {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-1359


### Change description ###
 - Updated appeal submission creator to handle `editAppealAfterSubmit` event.
 - Added a functional test to check that document is created.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
