### PR TITLE
RIA-3246 change appeal-type

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -58,7 +58,6 @@ withPipeline(type, product, component) {
     env.EM_BUNDLER_URL = "http://em-ccd-orchestrator-aat.service.core-compute-aat.internal"
     env.EM_BUNDLER_STITCH_URI = "/api/stitch-ccd-bundles"
 
-    installCharts()
     enableAksStagingDeployment()
     disableLegacyDeployment()
     loadVaultSecrets(secrets)

--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,7 @@ repositories {
 dependencyManagement {
     dependencies {
         // CVE-2019-0232, CVE-2019-0199 - command line injections on windows
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.31') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.35') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -48,7 +48,7 @@
   <suppress until="2030-01-01">
     <notes><![CDATA[
      Suppressing as SMTP appender is not used in this project (see: https://nvd.nist.gov/vuln/detail/CVE-2020-9488)
-      ]]></notes>
+   ]]></notes>
     <gav regex="true">org.apache.logging.log4j:log4j.*</gav>
     <cpe>cpe:/a:apache:log4j:2.12.1</cpe>
     <cve>CVE-2020-9488</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RIA-3246](https://tools.hmcts.net/jira/browse/RIA-3246)


### Change description ###

See Jira. This PR includes the removal of the deprecated installCharts() in Jenkins_CNP and Tomcat version bump.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
