### PR TITLE
sonar fix for non-compliant assert in unit test

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/clients/DocmosisDocumentConversionClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/clients/DocmosisDocumentConversionClientTest.java
@@ -77,7 +77,7 @@ public class DocmosisDocumentConversionClientTest {
             .extracting("file")
             .isEqualTo(tempSourceFile);
 
-        assertThat(convertedBytes).isEqualTo(convertedBytes);
+        assertThat(convertedBytes).isEqualTo(someRandomBytes);
     }
 
     @Test


### PR DESCRIPTION

### JIRA link (if applicable) ###

N/A


### Change description ###

Bug in unit test. Removing assertion comparing an object to itself.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
