### PR TITLE
RIA-3634: addressed CVE (CVE-2020-17527) by updating embed tomcat version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,7 +246,7 @@ repositories {
 dependencyManagement {
     dependencies {
         // CVE-2019-0232, CVE-2019-0199 - command line injections on windows
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.37') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.40') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-embed-websocket'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-3634


### Change description ###
addressed CVE (CVE-2020-17527) by updating embed tomcat version


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
