### PR TITLE
RIA-6121 Change HO permission roles for bail events

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -262,7 +262,7 @@ security:
       - "generateUpperTribunalBundle"
       - "recordTheDecision"
       - "endApplication"
-    caseworker-ia-respondentofficer:
+    caseworker-ia-homeofficebail:
       - "submitApplication"
       - "makeNewApplication"
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-6121


### Change description ###
This is to allow any home office user with home office bails to process bails events


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
