### PR TITLE
Ria 6424

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/AppealSubmissionTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/AppealSubmissionTemplate.java
@@ -242,13 +242,14 @@ public class AppealSubmissionTemplate implements DocumentTemplate<AsylumCase> {
                 fieldValues.put("nomsAvailable", nomsAvailable);
 
                 YesOrNo releaseDateProvided = YesOrNo.NO;
-                String prisonerReleaseDate = formatComplexString(asylumCase
-                        .get("dateCustodialSentence")
-                        .toString());
-
-                if (!prisonerReleaseDate.isBlank()) {
-                    releaseDateProvided = YesOrNo.YES;
-                    fieldValues.put("releaseDate", prisonerReleaseDate);
+                if (asylumCase.containsKey("dateCustodialSentence")) {
+                    String prisonerReleaseDate = formatComplexString(asylumCase
+                            .get("dateCustodialSentence")
+                            .toString());
+                    if (!prisonerReleaseDate.isBlank()) {
+                        releaseDateProvided = YesOrNo.YES;
+                        fieldValues.put("releaseDate", prisonerReleaseDate);
+                    }
                 }
                 fieldValues.put("releaseDateProvided", releaseDateProvided);
                 break;

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/AppealSubmissionTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/AppealSubmissionTemplateTest.java
@@ -279,6 +279,7 @@ public class AppealSubmissionTemplateTest {
         asylumCase.put("prisonNOMSNumber", nomsNumber);
         when(asylumCase.get("prisonNOMSNumber")).thenReturn(nomsNumber);
 
+        when(asylumCase.containsKey("dateCustodialSentence")).thenReturn(true);
         asylumCase.put("dateCustodialSentence", prisonerReleaseDate);
         when(asylumCase.get("dateCustodialSentence")).thenReturn(prisonerReleaseDate);
 


### PR DESCRIPTION
Bug in RIA-6424. When editing an appeal as admin AFTER submitting, and changing from IRC to prison, and selecting "Yes" to the prisoner release date question but leaving the value empty, this causes the backend to try read the custodialReleaseDate field when it is not supplied.

Now there is an extra check to ensure prisonerNOMSNumber field is present.
I have double checked other fields where asylumCase.get() method is used (nomsNumber & otherDetentionFacilityName) & a guard to check if these 2 fields are present is not needed as:
- nomsNumber always supplied to server even if its empty (as its an optional field)
- otherDetentionFacilityName is a mandatory field so will always be supplied to server


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
