### PR TITLE
RIA-7043 add NOTICE_OF_DECISION_UT_TRANSFER document tag

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
@@ -37,6 +37,7 @@ public enum DocumentTag {
     APPEAL_REASONS("appealReasons", CaseType.ASYLUM),
     CLARIFYING_QUESTIONS("clarifyingQuestions", CaseType.ASYLUM),
     APPEAL_FORM("appealForm", CaseType.ASYLUM),
+    NOTICE_OF_DECISION_UT_TRANSFER("noticeOfDecisionUtTransfer", CaseType.ASYLUM),
     BAIL_SUBMISSION("bailSubmission", CaseType.BAIL),
     BAIL_EVIDENCE("uploadTheBailEvidenceDocs", CaseType.BAIL),
     BAIL_DECISION_UNSIGNED("bailDecisionUnsigned", CaseType.BAIL),

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
@@ -94,6 +94,8 @@ public class BundleOrder implements Comparator<DocumentWithMetadata> {
                 return 30;
             case APPEAL_FORM:
                 return 31;
+            case NOTICE_OF_DECISION_UT_TRANSFER:
+                return 32;
             default:
                 throw new IllegalStateException("document has unknown tag: " + document.getTag() + ", description: " + document.getDescription());
         }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
@@ -32,6 +32,7 @@ public class DocumentTagTest {
         assertEquals("appealReasons", DocumentTag.APPEAL_REASONS.toString());
         assertEquals("clarifyingQuestions", DocumentTag.CLARIFYING_QUESTIONS.toString());
         assertEquals("appealForm", DocumentTag.APPEAL_FORM.toString());
+        assertEquals("noticeOfDecisionUtTransfer", DocumentTag.NOTICE_OF_DECISION_UT_TRANSFER.toString());
         assertEquals("bailSubmission", DocumentTag.BAIL_SUBMISSION.toString());
         assertEquals("uploadTheBailEvidenceDocs", DocumentTag.BAIL_EVIDENCE.toString());
         assertEquals("bailDecisionUnsigned", DocumentTag.BAIL_DECISION_UNSIGNED.toString());
@@ -45,6 +46,6 @@ public class DocumentTagTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(39, DocumentTag.values().length);
+        assertEquals(40, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
@@ -37,7 +37,7 @@ public class BundleOrderTest {
             .map(DocumentWithMetadata::getTag)
             .collect(Collectors.toList());
 
-        assertEquals(33, sortedTags.size());
+        assertEquals(34, sortedTags.size());
 
         List<DocumentTag> documentTagList = Arrays.asList(
             DocumentTag.CASE_SUMMARY,


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7043


### Change description ###
* Added NOTICE_OF_DECISION_UT_TRANSFER enum to DocumentTag.java


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
