### PR TITLE
RIA-7384 Enforce conventions on commit messages and branches

### DIFF
--- a/.git-config/hooks/commit-msg
+++ b/.git-config/hooks/commit-msg
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+REGEX_ISSUE_ID='^RIA-[0-9]+ .*'
+REGEX_GENERIC_TASK='^RIA-TASK .*'
+REGEX_SNOW_ISSUE_ID='^SNI-[0-9]+ .*'
+REGEX_RENOVATE='^Update .*'
+REGEX_RENOVATE_BRANCH='renovate\/.*'
+REGEX_MERGE='Merge branch .*'
+REGEX_REVERT='Revert .*'
+
+COMMIT_MESSAGE=$(head -n 1 "$1")
+
+
+if [[ $COMMIT_MESSAGE =~ $REGEX_ISSUE_ID ]]; then
+  # This is a RIA-nnnn commit message. All good.
+  exit 0
+fi
+
+if [[ $COMMIT_MESSAGE =~ $REGEX_SNOW_ISSUE_ID ]]; then
+  # This is a SNI-nnnn commit message. All good.
+  exit 0
+fi
+
+
+if [[ $COMMIT_MESSAGE =~ $REGEX_GENERIC_TASK ]]; then
+  # This is a CIV-TASK commit message. All good.
+  exit 0
+fi
+
+if [[ $COMMIT_MESSAGE =~ $REGEX_RENOVATE ]]; then
+  # This is a Renovate commit message. We need to check the branch name
+  BRANCH_NAME=$(git symbolic-ref --short HEAD)
+  if [[ $BRANCH_NAME =~ $REGEX_RENOVATE_BRANCH ]]; then
+    # Renovate commit message in renovate branch. All good.
+    exit 0
+  fi
+fi
+
+if [[ $COMMIT_MESSAGE =~ $REGEX_MERGE ]]; then
+  # This is a merge done locally. All good.
+  exit 0
+fi
+
+if [[ $COMMIT_MESSAGE =~ $REGEX_REVERT ]]; then
+  # This is a revert. All good.
+  exit 0
+fi
+
+
+# We don't recognize this commit message format, so it's invalid to us. We report an error to the user and exit.
+echo "The provided commit message is invalid. Commit messages must start with RIA-nnnn, SNI-nnnn or RIA-TASK"
+echo " (mind the uppercase) and there must be a space afterwards, to separate from the commit title."
+echo "Also be advised that usage of RIA-TASK should be cleared beforehand by a Technical Lead as its use is meant"
+echo " as an exception for corner cases."
+echo ""
+echo "Examples of valid commit messages:"
+echo " RIA-1234 Fixing a bug"
+echo " SNI-1234 Fixing a bug"
+echo " RIA-TASK Fixing an urgent issue in master"
+echo " RIA-TASK DET-1234 Fix from another project's team"
+echo ""
+echo "Examples of invalid commit messages:"
+echo " Fixing a bug"
+echo " DET-1234 Fix from another project's team"
+echo " $COMMIT_MESSAGE"
+
+exit 1

--- a/.git-config/hooks/pre-commit
+++ b/.git-config/hooks/pre-commit
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+LOCAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+RENOVATE_PREFIX="^renovate/"
+GITHUB_REVERT_PREFIX="^revert-[0-9]{1,5}.*"
+
+VALID_PREFIXES="^(feat|spike|fix|test|refactor)\/(.*)"
+VALID_TICKET_1='RIA-[0-9]{1,5}$'
+VALID_TICKET_2='RIA-[0-9]{1,5}[-_][a-z0-9]+.*'
+VALID_TICKET_3='SNI-[0-9]{1,5}$'
+VALID_TICKET_4='SNI-[0-9]{1,5}[-_][a-z0-9]+.*'
+VALID_TASK_1='RIA-TASK$'
+VALID_TASK_2='RIA-TASK[-_][a-z0-9]+.*'
+
+
+
+if [[ $LOCAL_BRANCH =~ $RENOVATE_PREFIX ]]; then
+  # This is a renovate branch. We don't check anything else.
+  exit 0
+fi
+
+if [[ $LOCAL_BRANCH =~ $GITHUB_REVERT_PREFIX ]]; then
+  # This is a revert branch created from GitHub. We don't check anything else.
+  exit 0
+fi
+
+
+if [[ ! $LOCAL_BRANCH =~ $VALID_PREFIXES ]]; then
+  # No valid prefix, we need to fail the script
+  echo "The provided branch prefix is missing or invalid. All branches not created automatically must start with one of:"
+  echo "  feat/"
+  echo "  spike/"
+  echo "  fix/"
+  echo "  test/"
+  echo "  refactor/"
+  echo ""
+  echo "Please rename your branch. To rename your branch you can use the following command:"
+  echo "  git branch -m <newname>"
+  exit 1
+fi
+
+BRANCH_PREFIX=${BASH_REMATCH[1]}
+BRANCH_NAME=${BASH_REMATCH[2]}
+
+if [[ $BRANCH_NAME =~ $VALID_TICKET_1 ]]; then
+  exit 0
+fi
+
+if [[ $BRANCH_NAME =~ $VALID_TICKET_2 ]]; then
+  exit 0
+fi
+
+if [[ $BRANCH_NAME =~ $VALID_TICKET_3 ]]; then
+  exit 0
+fi
+
+if [[ $BRANCH_NAME =~ $VALID_TICKET_4 ]]; then
+  exit 0
+fi
+
+if [[ $BRANCH_NAME =~ $VALID_TASK_1 ]]; then
+  exit 0
+fi
+
+if [[ $BRANCH_NAME =~ $VALID_TASK_2 ]]; then
+  exit 0
+fi
+
+echo "The provided branch name is invalid. Branches names (minus the prefix) must start with CIV-nnnn or CIV-TASK."
+echo "Optionally, they can be followed by a dash symbol and a description, rigorously lowercase."
+echo ""
+echo "Please rename your branch. To rename your branch you can use the following command:"
+echo "  git branch -m <newname>"
+echo ""
+echo "Examples of valid branch names (with prefix):"
+echo "  ${BRANCH_PREFIX}/RIA-1234"
+echo "  ${BRANCH_PREFIX}/RIA-1234-updating-something"
+echo "  ${BRANCH_PREFIX}/SNI-1234"
+echo "  ${BRANCH_PREFIX}/SNI-1234-updating-something"
+echo "  ${BRANCH_PREFIX}/RIA-TASK-det-3456-some-external-change"
+echo "  renovate/something"
+echo ""
+echo "Examples of invalid branch names (with prefix):"
+echo "  ${BRANCH_PREFIX}/RIA-1234-"
+echo "  ${BRANCH_PREFIX}/ria-1234"
+echo "  ${BRANCH_PREFIX}/DET-3456-some-external-change"
+echo "  ${BRANCH_PREFIX}/RIA-1234-Some-Change-WIth-Uppercase-Letters-In-Branch-Name"
+echo "  $LOCAL_BRANCH"
+
+
+exit 1
+

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,18 @@
+name: Does PR title match RIA-nnnn or SNI-nnnn?
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    if: "!contains(github.event.pull_request.head.ref, 'renovate') && !contains(github.event.pull_request.head.ref, 'dependabot')"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: deepakputhraya/action-pr-title@master
+      with:
+        regex: '^(RIA-[0-9]{3,4} [a-zA-Z0-9._\- ]+)|(SNI-[0-9]{3,4} [a-zA-Z0-9._\- ]+)|(RIA-TASK [a-zA-Z0-9._\- ]+)|(\[Snyk\].+)$' # Regex the title should match.
+        prefix_case_sensitive: true # title prefix are case insensitive:

--- a/README.md
+++ b/README.md
@@ -85,4 +85,34 @@ As the project grows, these tests will take longer and longer to execute but are
 
 More information about mutation testing can be found here:
 http://pitest.org/
- 
+
+
+## Adding Git Conventions
+
+### Include the git conventions.
+* Make sure your git version is at least 2.9 using the `git --version` command
+* Run the following command:
+```
+git config --local core.hooksPath .git-config/hooks
+```
+Once the above is done, you will be required to follow specific conventions for your commit messages and branch names.
+
+If you violate a convention, the git error message will report clearly the convention you should follow and provide
+additional information where necessary.
+
+*Optional:*
+* Install this plugin in Chrome: https://github.com/refined-github/refined-github
+
+  It will automatically set the title for new PRs according to the first commit message, so you won't have to change it manually.
+
+  Note that it will also alter other behaviours in GitHub. Hopefully these will also be improvements to you.
+
+*In case of problems*
+
+1. Get in touch with your Technical Lead and inform them, so they can adjust the git hooks accordingly
+2. Instruct IntelliJ not to use Git Hooks for that commit or use git's `--no-verify` option if you are using the command-line
+3. If the rare eventuality that the above is not possible, you can disable enforcement of conventions using the following command
+
+   `git config --local --unset core.hooksPath`
+
+   Still, you shouldn't be doing it so make sure you get in touch with a Technical Lead soon afterwards.

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,7 +20,7 @@
         ]]</notes>
         <cve>CVE-2022-45688</cve>
     </suppress>
-    <suppress until="2023-07-27">
+    <suppress until="2023-07-29">
         <cve>CVE-2023-20862</cve>
         <cve>CVE-2023-20860</cve>
         <cve>CVE-2023-20863</cve>
@@ -28,5 +28,6 @@
         <cve>CVE-2023-28709</cve>
         <cve>CVE-2023-20883</cve>
         <cve>CVE-2023-35116</cve>
+        <cve>CVE-2023-2976</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
RIA-7384

### Change description ###
Add git hooks to help enforcing conventions.
Developers will need to opt-in to this, so it's not going to be disruptive.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
