### PR TITLE
RIA-7175 Internal ADA suitability document - unsuitable

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -27,5 +27,7 @@
         <cve>CVE-2023-20873</cve>
         <cve>CVE-2023-28709</cve>
         <cve>CVE-2023-20883</cve>
+        <cve>CVE-2023-35116</cve>
+        <cve>CVE-2023-2976</cve>
     </suppress>
 </suppressions>

--- a/src/functionalTest/resources/scenarios/RIA-7175-internal-ada-suitability-unsuitable-document.json
+++ b/src/functionalTest/resources/scenarios/RIA-7175-internal-ada-suitability-unsuitable-document.json
@@ -1,0 +1,45 @@
+{
+  "description": "RIA-7175 ADA suitability review - Unsuitable - document generation",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "eventId": "adaSuitabilityReview",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "isAcceleratedDetainedAppeal": "Yes",
+          "suitabilityReviewJudge": "Judge x",
+          "suitabilityReviewDecision": "unsuitable",
+          "suitabilityReviewReason": "Reason1"
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "internalAdaSuitability",
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_filename": "PA 12345 2019-Awan-ADA-Appellant-letter-suitability-decision-unsuitable.PDF",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/"
+              },
+              "suppliedBy": "",
+              "description": "",
+              "dateUploaded": "{$TODAY}"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
@@ -15,7 +15,7 @@ public enum DocumentTag {
     HEARING_NOTICE("hearingNotice", CaseType.ASYLUM),
     REHEARD_HEARING_NOTICE("reheardHearingNotice", CaseType.ASYLUM),
     ADA_SUITABILITY("adaSuitability", CaseType.ASYLUM),
-
+    INTERNAL_ADA_SUITABILITY("internalAdaSuitability", CaseType.ASYLUM),
     CASE_SUMMARY("caseSummary", CaseType.ASYLUM),
     HEARING_BUNDLE("hearingBundle", CaseType.ASYLUM),
     ADDENDUM_EVIDENCE("addendumEvidence", CaseType.ASYLUM),

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/InternalAdaSuitabilityReviewUnsuitableLetterGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/InternalAdaSuitabilityReviewUnsuitableLetterGenerator.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.*;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+
+@Component
+public class InternalAdaSuitabilityReviewUnsuitableLetterGenerator implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final DocumentCreator<AsylumCase> internalAdaSuitabilityReviewUnsuitableLetterGenerator;
+    private final DocumentHandler documentHandler;
+
+    public InternalAdaSuitabilityReviewUnsuitableLetterGenerator(
+        @Qualifier("internalAdaSuitabilityUnsuitable") DocumentCreator<AsylumCase> internalAdaSuitabilityReviewUnsuitableLetterGenerator,
+        DocumentHandler documentHandler
+    ) {
+        this.internalAdaSuitabilityReviewUnsuitableLetterGenerator = internalAdaSuitabilityReviewUnsuitableLetterGenerator;
+        this.documentHandler = documentHandler;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        return callback.getEvent() == Event.ADA_SUITABILITY_REVIEW
+               && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && isInternalCase(asylumCase)
+               && isAcceleratedDetainedAppeal(asylumCase);
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        Document internalAdaSuitabilityUnsuitableLetterDocument = internalAdaSuitabilityReviewUnsuitableLetterGenerator.create(caseDetails);
+
+        final AdaSuitabilityReviewDecision suitabilityDecision =
+            asylumCase.read(AsylumCaseDefinition.SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)
+                .orElseThrow(() -> new RequiredFieldMissingException("ADA suitability decision is missing."));
+
+        if (suitabilityDecision.equals(AdaSuitabilityReviewDecision.UNSUITABLE)) {
+            documentHandler.addWithMetadata(
+                asylumCase,
+                internalAdaSuitabilityUnsuitableLetterDocument,
+                NOTIFICATION_ATTACHMENT_DOCUMENTS,
+                DocumentTag.INTERNAL_ADA_SUITABILITY
+            );
+        }
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
@@ -99,6 +99,9 @@ public class BundleOrder implements Comparator<DocumentWithMetadata> {
             case REQUEST_CASE_BUILDING:
                 log.warn("REQUEST_CASE_BUILDING tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
                 return 33;
+            case INTERNAL_ADA_SUITABILITY:
+                log.warn("INTERNAL_ADA_SUITABILITY tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
+                return 34;
             default:
                 throw new IllegalStateException("document has unknown tag: " + document.getTag() + ", description: " + document.getDescription());
         }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/InternalAdaSuitabilityReviewUnsuitableLetterTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/InternalAdaSuitabilityReviewUnsuitableLetterTemplate.java
@@ -1,0 +1,60 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates;
+
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+
+@Component
+public class InternalAdaSuitabilityReviewUnsuitableLetterTemplate implements DocumentTemplate<AsylumCase> {
+
+    private final String templateName;
+    private final CustomerServicesProvider customerServicesProvider;
+
+    public InternalAdaSuitabilityReviewUnsuitableLetterTemplate(
+        @Value("${adaInternalSuitabilityReviewUnsuitableDocument.templateName}") String templateName,
+        CustomerServicesProvider customerServicesProvider
+    ) {
+        this.templateName = templateName;
+        this.customerServicesProvider = customerServicesProvider;
+    }
+
+    public String getName() {
+        return templateName;
+    }
+
+    public Map<String, Object> mapFieldValues(
+        CaseDetails<AsylumCase> caseDetails
+    ) {
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        final Map<String, Object> fieldValues = new HashMap<>();
+
+        fieldValues.put("hmcts", "[userImage:hmcts.png]");
+        fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalAdaCustomerServicesTelephone());
+        fieldValues.put("ADAemail", customerServicesProvider.getInternalAdaCustomerServicesEmail());
+        fieldValues.put("appealReferenceNumber", asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class).orElse(""));
+        fieldValues.put("homeOfficeReferenceNumber", asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class).orElse(""));
+        fieldValues.put("dateLetterSent", formatDateForNotificationAttachmentDocument(LocalDate.now()));
+
+        fieldValues.put("appellantGivenNames", asylumCase.read(APPELLANT_GIVEN_NAMES, String.class).orElse(""));
+        fieldValues.put("appellantFamilyName", asylumCase.read(APPELLANT_FAMILY_NAME, String.class).orElse(""));
+
+        fieldValues.put("hearingType", asylumCase.read(REMOTE_VIDEO_CALL_TRIBUNAL_RESPONSE, String.class).orElse(null));
+        fieldValues.put("vulnerabilities", asylumCase.read(VULNERABILITIES_TRIBUNAL_RESPONSE, String.class).orElse(null));
+        fieldValues.put("pastExperiences", asylumCase.read(PAST_EXPERIENCES_TRIBUNAL_RESPONSE, String.class).orElse(null));
+        fieldValues.put("multimedia", asylumCase.read(MULTIMEDIA_TRIBUNAL_RESPONSE, String.class).orElse(null));
+        fieldValues.put("singleSexCourt", asylumCase.read(SINGLE_SEX_COURT_TRIBUNAL_RESPONSE, String.class).orElse(null));
+        fieldValues.put("inCamera", asylumCase.read(IN_CAMERA_COURT_TRIBUNAL_RESPONSE, String.class).orElse(null));
+        fieldValues.put("otherHearingRequest", asylumCase.read(ADDITIONAL_TRIBUNAL_RESPONSE, String.class).orElse(null));
+
+        return fieldValues;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
@@ -266,6 +266,27 @@ public class DocumentCreatorConfiguration {
         );
     }
 
+    @Bean("internalAdaSuitabilityUnsuitable")
+    public DocumentCreator<AsylumCase> getInternalAdaSuitabilityLetterUnsuitableDocumentCreator(
+        @Value("${adaInternalSuitabilityReviewUnsuitableDocument.contentType}") String contentType,
+        @Value("${adaInternalSuitabilityReviewUnsuitableDocument.fileExtension}") String fileExtension,
+        @Value("${adaInternalSuitabilityReviewUnsuitableDocument.fileName}") String fileName,
+        AsylumCaseFileNameQualifier fileNameQualifier,
+        InternalAdaSuitabilityReviewUnsuitableLetterTemplate documentTemplate,
+        DocumentGenerator documentGenerator,
+        DocumentUploader documentUploader
+    ) {
+        return new DocumentCreator<>(
+            contentType,
+            fileExtension,
+            fileName,
+            fileNameQualifier,
+            documentTemplate,
+            documentGenerator,
+            documentUploader
+        );
+    }
+
     @Bean("decisionAndReasons")
     public DocumentCreator<AsylumCase> getAndDecisionAndReasonsDocumentCreator(
         @Value("${decisionAndReasons.contentType}") String contentType,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -104,6 +104,11 @@ adaSuitabilityDocument.fileExtension: PDF
 adaSuitabilityDocument.fileName: "ADA-suitability-decision"
 adaSuitabilityDocument.templateName: ${IA_ADA_SUITABILITY_TEMPLATE:TB-IAC-DEC-ENG-00001.docx}
 
+adaInternalSuitabilityReviewUnsuitableDocument.contentType: application/pdf
+adaInternalSuitabilityReviewUnsuitableDocument.fileExtension: PDF
+adaInternalSuitabilityReviewUnsuitableDocument.fileName: "ADA-Appellant-letter-suitability-decision-unsuitable"
+adaInternalSuitabilityReviewUnsuitableDocument.templateName: ${IA_ADA_INTERNAL_SUITABILITY_UNSUITABLE_TEMPLATE:TB-IAC-DEC-ENG-00005.docx}
+
 internalAdaRequestBuildCaseDocument.contentType: application/pdf
 internalAdaRequestBuildCaseDocument.fileExtension: PDF
 internalAdaRequestBuildCaseDocument.fileName: "ADA appellant letter-appeal reasons"

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
@@ -43,11 +43,11 @@ public class DocumentTagTest {
         assertEquals("b1Document", DocumentTag.B1_DOCUMENT.toString());
         assertEquals("", DocumentTag.NONE.toString());
         assertEquals("requestCaseBuilding", DocumentTag.REQUEST_CASE_BUILDING.toString());
-
+        assertEquals("internalAdaSuitability", DocumentTag.INTERNAL_ADA_SUITABILITY.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(41, DocumentTag.values().length);
+        assertEquals(42, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/InternalAdaSuitabilityReviewUnsuitableLetterGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/InternalAdaSuitabilityReviewUnsuitableLetterGeneratorTest.java
@@ -1,0 +1,215 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AdaSuitabilityReviewDecision;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class InternalAdaSuitabilityReviewUnsuitableLetterGeneratorTest {
+
+    @Mock private DocumentCreator<AsylumCase> internalAdaSuitabilityUnsuitableDocumentCreator;
+    @Mock private DocumentHandler documentHandler;
+    @Mock private Callback<AsylumCase> callback;
+    @Mock private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private Document uploadedDocument;
+
+    private InternalAdaSuitabilityReviewUnsuitableLetterGenerator internalAdaSuitabilityReviewUnsuitableLetterGenerator;
+
+    @BeforeEach
+    public void setUp() {
+        internalAdaSuitabilityReviewUnsuitableLetterGenerator =
+            new InternalAdaSuitabilityReviewUnsuitableLetterGenerator(
+                internalAdaSuitabilityUnsuitableDocumentCreator,
+                documentHandler
+            );
+    }
+
+    @Test
+    public void should_create_internal_ada_suitability_unsuitable_document_and_append_to_notifications_documents() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.ADA_SUITABILITY_REVIEW);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getCaseDetails().getCaseData().read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getCaseDetails().getCaseData().read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.of(AdaSuitabilityReviewDecision.UNSUITABLE));
+
+        when(internalAdaSuitabilityUnsuitableDocumentCreator.create(caseDetails)).thenReturn(uploadedDocument);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            internalAdaSuitabilityReviewUnsuitableLetterGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(documentHandler, times(1)).addWithMetadata(asylumCase, uploadedDocument, NOTIFICATION_ATTACHMENT_DOCUMENTS, DocumentTag.INTERNAL_ADA_SUITABILITY);
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.SUBMIT_APPEAL);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getCaseDetails().getCaseData().read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        assertThatThrownBy(() -> internalAdaSuitabilityReviewUnsuitableLetterGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+
+        assertThatThrownBy(() -> internalAdaSuitabilityReviewUnsuitableLetterGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void it_cannot_handle_callback_if_is_admin_is_missing() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+            when(callback.getCaseDetails().getCaseData().read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = internalAdaSuitabilityReviewUnsuitableLetterGenerator.canHandle(callbackStage, callback);
+                assertFalse(canHandle);
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void it_cannot_handle_callback_if_is_ada_is_missing() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+            when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = internalAdaSuitabilityReviewUnsuitableLetterGenerator.canHandle(callbackStage, callback);
+                assertFalse(canHandle);
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void it_cannot_handle_callback_if_suitability_decision_is_suitable() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+            when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+            when(callback.getCaseDetails().getCaseData().read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.of(AdaSuitabilityReviewDecision.SUITABLE));
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = internalAdaSuitabilityReviewUnsuitableLetterGenerator.canHandle(callbackStage, callback);
+                assertFalse(canHandle);
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_throw_when_suitability_decision_is_not_present() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.ADA_SUITABILITY_REVIEW);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getCaseDetails().getCaseData().read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getCaseDetails().getCaseData().read(SUITABILITY_REVIEW_DECISION, AdaSuitabilityReviewDecision.class)).thenReturn(Optional.empty());
+
+        when(internalAdaSuitabilityUnsuitableDocumentCreator.create(caseDetails)).thenReturn(uploadedDocument);
+
+        assertThatThrownBy(() -> internalAdaSuitabilityReviewUnsuitableLetterGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .isExactlyInstanceOf(RequiredFieldMissingException.class)
+            .hasMessage("ADA suitability decision is missing.");
+    }
+
+    @Test
+    public void it_cannot_handle_callback_if_suitability_decision_is_missing() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+            when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = internalAdaSuitabilityReviewUnsuitableLetterGenerator.canHandle(callbackStage, callback);
+                assertFalse(canHandle);
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void it_should_only_handle_about_to_submit_and_ada_suitability_review_event() {
+        for (Event event : Event.values()) {
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+            when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+            when(callback.getCaseDetails().getCaseData().read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = internalAdaSuitabilityReviewUnsuitableLetterGenerator.canHandle(callbackStage, callback);
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                    && callback.getEvent().equals(Event.ADA_SUITABILITY_REVIEW)) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+        assertThatThrownBy(() -> internalAdaSuitabilityReviewUnsuitableLetterGenerator.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> internalAdaSuitabilityReviewUnsuitableLetterGenerator.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+
+        assertThatThrownBy(() -> internalAdaSuitabilityReviewUnsuitableLetterGenerator.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> internalAdaSuitabilityReviewUnsuitableLetterGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
@@ -37,7 +37,7 @@ public class BundleOrderTest {
             .map(DocumentWithMetadata::getTag)
             .collect(Collectors.toList());
 
-        assertEquals(35, sortedTags.size());
+        assertEquals(36, sortedTags.size());
 
         List<DocumentTag> documentTagList = Arrays.asList(
             DocumentTag.CASE_SUMMARY,

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/InternalAdaSuitabilityReviewUnsuitableLetterTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/InternalAdaSuitabilityReviewUnsuitableLetterTemplateTest.java
@@ -1,0 +1,105 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.time.LocalDate;
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class InternalAdaSuitabilityReviewUnsuitableLetterTemplateTest {
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CustomerServicesProvider customerServicesProvider;
+    private final String templateName = "TB-IAC-DEC-ENG-00005.docx";
+    private final String internalAdaCustomerServicesTelephoneNumber = "0300 123 1234";
+    private final String internalAdaCustomerServicesEmailAddress = "example@email.com";
+    private final String appealReferenceNumber = "RP/11111/2020";
+    private final String homeOfficeReferenceNumber = "A1234567/001";
+    private final String appellantGivenNames = "John";
+    private final String appellantFamilyName = "Doe";
+    private final LocalDate now = LocalDate.now();
+    private final String hearingType = "Video hearing type response";
+    private final String vulnerabilities = "Health issues response";
+    private final String pastExperiences = "Past experiences response";
+    private final String multimedia = "Multimedia response";
+    private final String singleSexCourt = "Single-sex response";
+    private final String inCamera = "Private hearing response";
+    private final String otherHearingRequest = "Other response";
+
+    private InternalAdaSuitabilityReviewUnsuitableLetterTemplate internalAdaSuitabilityReviewUnsuitableLetterTemplate;
+
+    @BeforeEach
+    void setUp() {
+        internalAdaSuitabilityReviewUnsuitableLetterTemplate =
+            new InternalAdaSuitabilityReviewUnsuitableLetterTemplate(
+                templateName,
+                customerServicesProvider
+            );
+    }
+
+    @Test
+    void should_return_template_name() {
+        assertEquals(templateName, internalAdaSuitabilityReviewUnsuitableLetterTemplate.getName());
+    }
+
+    void dataSetUp() {
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(REMOTE_VIDEO_CALL_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(hearingType));
+        when(asylumCase.read(VULNERABILITIES_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(vulnerabilities));
+        when(asylumCase.read(PAST_EXPERIENCES_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(pastExperiences));
+        when(asylumCase.read(MULTIMEDIA_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(multimedia));
+        when(asylumCase.read(SINGLE_SEX_COURT_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(singleSexCourt));
+        when(asylumCase.read(IN_CAMERA_COURT_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(inCamera));
+        when(asylumCase.read(ADDITIONAL_TRIBUNAL_RESPONSE, String.class)).thenReturn(Optional.of(otherHearingRequest));
+
+        when(customerServicesProvider.getInternalAdaCustomerServicesTelephone()).thenReturn(internalAdaCustomerServicesTelephoneNumber);
+        when(customerServicesProvider.getInternalAdaCustomerServicesEmail()).thenReturn(internalAdaCustomerServicesEmailAddress);
+    }
+
+    @Test
+    void should_map_case_data_to_template_field_values() {
+        dataSetUp();
+
+        Map<String, Object> templateFieldValues = internalAdaSuitabilityReviewUnsuitableLetterTemplate.mapFieldValues(caseDetails);
+
+        assertEquals(15, templateFieldValues.size());
+        assertEquals("[userImage:hmcts.png]", templateFieldValues.get("hmcts"));
+        assertEquals(appealReferenceNumber, templateFieldValues.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, templateFieldValues.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, templateFieldValues.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, templateFieldValues.get("appellantFamilyName"));
+        assertEquals(internalAdaCustomerServicesTelephoneNumber, templateFieldValues.get("customerServicesTelephone"));
+        assertEquals(internalAdaCustomerServicesEmailAddress, templateFieldValues.get("ADAemail"));
+        assertEquals(hearingType, templateFieldValues.get("hearingType"));
+        assertEquals(vulnerabilities, templateFieldValues.get("vulnerabilities"));
+        assertEquals(pastExperiences, templateFieldValues.get("pastExperiences"));
+        assertEquals(multimedia, templateFieldValues.get("multimedia"));
+        assertEquals(singleSexCourt, templateFieldValues.get("singleSexCourt"));
+        assertEquals(inCamera, templateFieldValues.get("inCamera"));
+        assertEquals(otherHearingRequest, templateFieldValues.get("otherHearingRequest"));
+
+        assertEquals(formatDateForNotificationAttachmentDocument(now), templateFieldValues.get("dateLetterSent"));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7175

### Change description ###

- New template for DET notification letter document attachment, unsuitable decision
- New generator and configuration bean created
- New document tag (reused from previous PR)
- Added to ignore in bundle order (reused from previous PR)
- Unit and functional tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
