### PR TITLE
RIA-7198: Generate letter when HO maintains decision in 'Upload Appea…

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -41,7 +41,10 @@ def secrets = [
         secret('gov-call-charges-url', 'IA_BAIL_GOV_CALL_CHARGES_URL'),
 
         secret('system-username', 'IA_SYSTEM_USERNAME'),
-        secret('system-password', 'IA_SYSTEM_PASSWORD')
+        secret('system-password', 'IA_SYSTEM_PASSWORD'),
+
+        secret('test-homeoffice-lart-username', 'TEST_HOMEOFFICE_LART_USERNAME'),
+        secret('test-homeoffice-lart-password', 'TEST_HOMEOFFICE_LART_PASSWORD')
     ]
 ]
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -43,7 +43,10 @@ def secrets = [
         secret('gov-call-charges-url', 'IA_BAIL_GOV_CALL_CHARGES_URL'),
 
         secret('system-username', 'IA_SYSTEM_USERNAME'),
-        secret('system-password', 'IA_SYSTEM_PASSWORD')
+        secret('system-password', 'IA_SYSTEM_PASSWORD'),
+
+        secret('test-homeoffice-lart-username', 'TEST_HOMEOFFICE_LART_USERNAME'),
+        secret('test-homeoffice-lart-password', 'TEST_HOMEOFFICE_LART_PASSWORD')
     ]
 ]
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -36,7 +36,10 @@ def secrets = [
 
         secret('customer-services-telephone', 'IA_CUSTOMER_SERVICES_TELEPHONE'),
         secret('customer-services-email', 'IA_CUSTOMER_SERVICES_EMAIL'),
-        secret('gov-call-charges-url', 'IA_BAIL_GOV_CALL_CHARGES_URL')
+        secret('gov-call-charges-url', 'IA_BAIL_GOV_CALL_CHARGES_URL'),
+
+        secret('test-homeoffice-lart-username', 'TEST_HOMEOFFICE_LART_USERNAME'),
+        secret('test-homeoffice-lart-password', 'TEST_HOMEOFFICE_LART_PASSWORD')
     ]
 ]
 

--- a/src/functionalTest/java/uk/gov/hmcts/reform/iacasedocumentsapi/CcdScenarioRunnerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/iacasedocumentsapi/CcdScenarioRunnerTest.java
@@ -318,6 +318,11 @@ public class CcdScenarioRunnerTest {
                     .getSystemAuthorization();
         }
 
+        if ("HomeOfficeLart".equalsIgnoreCase(credentials)) {
+
+            return authorizationHeadersProvider
+                    .getHomeOfficeLartAuthorization();
+        }
         return new Headers();
     }
 }

--- a/src/functionalTest/resources/scenarios/RIA-7198-upload-appeal-response-decision-maintained-letter-document.json
+++ b/src/functionalTest/resources/scenarios/RIA-7198-upload-appeal-response-decision-maintained-letter-document.json
@@ -1,0 +1,76 @@
+{
+  "description": "RIA-7198 HO Uploads Appeal Response Letter PDF - Decision maintained",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "HomeOfficeLart",
+    "input": {
+      "eventId": "uploadHomeOfficeAppealResponse",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "isAdmin": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "listCaseHearingDate": "2023-07-08T09:00:00.000",
+          "appealSubmissionDate": "2023-06-29",
+          "appealReviewOutcome": "decisionMaintained",
+          "directions": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "respondentReview",
+                "parties": "respondent",
+                "uniqueId": "eba53f77-a98e-47ed-af30-f0f4d3372f01",
+                "explanation": "You have until the date indicated below to review the appellant's argument and evidence. You must explain whether the appellant makes a valid case for overturning the original decision.\n\nYou must respond to the Tribunal and tell them:\n\n- whether you oppose all or parts of the appellant's case\n- what your grounds are for opposing the case\n- which of the issues are agreed or not agreed\n- whether there are any further issues you wish to raise\n- whether you are prepared to withdraw to grant\n- whether the appeal can be resolved without a hearing\n\nNext steps\n\nIf you do not respond in time the Tribunal will decide how the case should proceed.",
+                "directionType": "requestRespondentReview",
+                "dateDue": "{$TODAY+13}",
+                "dateSent": "{$TODAY}",
+                "previousDates": []
+              }
+            },
+            {
+              "id": "2",
+              "value": {
+                "tag": "requestCaseBuilding",
+                "parties": "legalRepresentative",
+                "uniqueId": "eba53f77-a98e-47ed-af30-f0f4d3372f26",
+                "explanation": "You must now build your case to enable the respondent to conduct a thorough review of their decision.\\n\\nYou have until the date indicated below to upload your Appeal Skeleton Argument and evidence.\\n\\nYour Appeal Skeleton Argument must be set out in three distinct parts to include:\\n\\n- a concise summary of the appellant’s case\\n- a schedule of issues\\n- why those issues should be resolved in the appellant’s favour, by reference to the evidence you have (or plan to have) and any legal authorities you rely upon\\n\\n# Next steps\\n\\nOnce you've uploaded your Appeal Skeleton Argument and evidence, you should submit your case. The Legal Officer will review everything you've added.\\n\\nIf your case looks ready, the Tribunal will send it to the respondent to review.",
+                "directionType": "requestCaseBuilding",
+                "dateDue": "{$TODAY+15}",
+                "dateSent": "{$TODAY}",
+                "previousDates": []
+              }
+            }
+          ],
+          "notificationAttachmentDocuments":[]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "isAdmin": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-HO-Response-Letter.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "uploadTheAppealResponse"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/AppealReviewOutcome.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/AppealReviewOutcome.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum AppealReviewOutcome {
+
+    DECISION_MAINTAINED("decisionMaintained"),
+    DECISION_WITHDRAWN("decisionWithdrawn");
+
+    @JsonValue
+    private final String value;
+
+    AppealReviewOutcome(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/AsylumCaseDefinition.java
@@ -525,7 +525,10 @@ public enum AsylumCaseDefinition {
 
     // Case data section to hold generated documents,so they can be attached to email notifications
     NOTIFICATION_ATTACHMENT_DOCUMENTS(
-            "notificationAttachmentDocuments", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){});
+            "notificationAttachmentDocuments", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
+
+    APPEAL_REVIEW_OUTCOME(
+        "appealReviewOutcome", new TypeReference<AppealReviewOutcome>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
@@ -42,6 +42,7 @@ public enum DocumentTag {
 
     REQUEST_CASE_BUILDING("requestCaseBuilding", CaseType.ASYLUM),
     REQUEST_RESPONDENT_REVIEW("requestRespondentReview", CaseType.ASYLUM),
+    UPLOAD_THE_APPEAL_RESPONSE("uploadTheAppealResponse", CaseType.ASYLUM),
 
     BAIL_SUBMISSION("bailSubmission", CaseType.BAIL),
     BAIL_EVIDENCE("uploadTheBailEvidenceDocs", CaseType.BAIL),

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
@@ -41,7 +41,7 @@ public enum Event {
     SUBMIT_REASONS_FOR_APPEAL("submitReasonsForAppeal", CaseType.ASYLUM),
     SUBMIT_CLARIFYING_QUESTION_ANSWERS("submitClarifyingQuestionAnswers", CaseType.ASYLUM),
     REQUEST_CASE_BUILDING("requestCaseBuilding", CaseType.ASYLUM),
-
+    UPLOAD_HOME_OFFICE_APPEAL_RESPONSE("uploadHomeOfficeAppealResponse", CaseType.ASYLUM),
     SUBMIT_APPLICATION("submitApplication", CaseType.BAIL),
     RECORD_THE_DECISION("recordTheDecision", CaseType.BAIL),
     END_APPLICATION("endApplication", CaseType.BAIL),

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/UploadTheAppealResponseLetterGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/UploadTheAppealResponseLetterGenerator.java
@@ -1,0 +1,80 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit.letter;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.APPEAL_REVIEW_OUTCOME;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.NOTIFICATION_ATTACHMENT_DOCUMENTS;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AppealReviewOutcome;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils;
+
+@Component
+public class UploadTheAppealResponseLetterGenerator implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final DocumentCreator<AsylumCase> uploadTheAppealResponseLetterCreator;
+    private final DocumentHandler documentHandler;
+
+    public UploadTheAppealResponseLetterGenerator(
+            @Qualifier("uploadTheAppealResponseLetter") DocumentCreator<AsylumCase> uploadTheAppealResponseLetterCreator,
+            DocumentHandler documentHandler
+    ) {
+        this.uploadTheAppealResponseLetterCreator = uploadTheAppealResponseLetterCreator;
+        this.documentHandler = documentHandler;
+    }
+
+    public boolean canHandle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        return callback.getEvent() == Event.UPLOAD_HOME_OFFICE_APPEAL_RESPONSE
+                && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && AsylumCaseUtils.isInternalCase(asylumCase)
+                && AsylumCaseUtils.isAcceleratedDetainedAppeal(asylumCase)
+                && getAppealReviewOutcome(asylumCase).equals("decisionMaintained");
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        Document uploadTheAppealResponseLetter = uploadTheAppealResponseLetterCreator.create(caseDetails);
+        documentHandler.addWithMetadata(
+                asylumCase,
+                uploadTheAppealResponseLetter,
+                NOTIFICATION_ATTACHMENT_DOCUMENTS,
+                DocumentTag.UPLOAD_THE_APPEAL_RESPONSE
+        );
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+
+    private String getAppealReviewOutcome(AsylumCase asylumCase) {
+        AppealReviewOutcome appealReviewOutcome = asylumCase.read(APPEAL_REVIEW_OUTCOME, AppealReviewOutcome.class)
+                .orElseThrow(() -> new IllegalStateException("Appeal review outcome is not present"));
+
+        return appealReviewOutcome.toString();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
@@ -108,6 +108,9 @@ public class BundleOrder implements Comparator<DocumentWithMetadata> {
             case INTERNAL_ADA_DECISION_AND_REASONS_LETTER:
                 log.warn("INTERNAL_ADA_DECISION_AND_REASONS_LETTER tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
                 return 36;
+            case UPLOAD_THE_APPEAL_RESPONSE:
+                log.warn("UPLOAD_THE_APPEAL_RESPONSE tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
+                return 37;
             default:
                 throw new IllegalStateException("document has unknown tag: " + document.getTag() + ", description: " + document.getDescription());
         }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/UploadAppealResponseMaintainedDecisionLetterTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/UploadAppealResponseMaintainedDecisionLetterTemplate.java
@@ -56,8 +56,8 @@ public class UploadAppealResponseMaintainedDecisionLetterTemplate implements Doc
         fieldValues.put("hmcts", "[userImage:hmcts.png]");
         fieldValues.put("dateLetterSent", formatDateForNotificationAttachmentDocument(dateProvider.now()));
         fieldValues.putAll(getAppellantPersonalisation(asylumCase));
-        fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalAdaCustomerServicesTelephone());
-        fieldValues.put("ADAemail", customerServicesProvider.getInternalAdaCustomerServicesEmail());
+        fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase));
+        fieldValues.put("ADAemail", customerServicesProvider.getInternalCustomerServicesEmail(asylumCase));
         fieldValues.put("suitabilityAssessmentHearingDate", getFormattedDate(getSaHearingDate(asylumCase)));
         fieldValues.put("hearingDate", getFormattedDate(getLocalDateForFieldValue(asylumCase, LIST_CASE_HEARING_DATE)));
         fieldValues.put("caseBuildingDueDate", formatDateForNotificationAttachmentDocument(LocalDate.parse(getDirectionDueDate(asylumCase, DirectionTag.REQUEST_CASE_BUILDING))));

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/UploadAppealResponseMaintainedDecisionLetterTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/UploadAppealResponseMaintainedDecisionLetterTemplate.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.LIST_CASE_HEARING_DATE;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.getAppellantPersonalisation;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.getDirectionDueDate;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.RequiredFieldMissingException;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DirectionTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DueDateService;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.DocumentTemplate;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+
+@Component
+public class UploadAppealResponseMaintainedDecisionLetterTemplate implements DocumentTemplate<AsylumCase> {
+
+    private static final DateTimeFormatter DOCUMENT_DATE_FORMAT = DateTimeFormatter.ofPattern("ddMMyyyy");
+    private final String templateName;
+    private final DateProvider dateProvider;
+    private final CustomerServicesProvider customerServicesProvider;
+    private final DueDateService dueDateService;
+
+    public UploadAppealResponseMaintainedDecisionLetterTemplate(
+            @Value("${uploadAppealResponseMaintainedLetter.templateName}") String templateName,
+            DateProvider dateProvider,
+            CustomerServicesProvider customerServicesProvider,
+            DueDateService dueDateService) {
+        this.templateName = templateName;
+        this.dateProvider = dateProvider;
+        this.customerServicesProvider = customerServicesProvider;
+        this.dueDateService = dueDateService;
+    }
+
+    public String getName() {
+
+        return templateName;
+    }
+
+    public Map<String, Object> mapFieldValues(
+        CaseDetails<AsylumCase> caseDetails
+    ) {
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        final Map<String, Object> fieldValues = new HashMap<>();
+
+        fieldValues.put("hmcts", "[userImage:hmcts.png]");
+        fieldValues.put("dateLetterSent", formatDateForNotificationAttachmentDocument(dateProvider.now()));
+        fieldValues.putAll(getAppellantPersonalisation(asylumCase));
+        fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalAdaCustomerServicesTelephone());
+        fieldValues.put("ADAemail", customerServicesProvider.getInternalAdaCustomerServicesEmail());
+        fieldValues.put("suitabilityAssessmentHearingDate", getFormattedDate(getSaHearingDate(asylumCase)));
+        fieldValues.put("hearingDate", getFormattedDate(getLocalDateForFieldValue(asylumCase, LIST_CASE_HEARING_DATE)));
+        fieldValues.put("caseBuildingDueDate", formatDateForNotificationAttachmentDocument(LocalDate.parse(getDirectionDueDate(asylumCase, DirectionTag.REQUEST_CASE_BUILDING))));
+        fieldValues.put("requestRespondentReviewDueDate", formatDateForNotificationAttachmentDocument(LocalDate.parse(getDirectionDueDate(asylumCase, DirectionTag.RESPONDENT_REVIEW))));
+        return fieldValues;
+    }
+
+    private String getFormattedDate(LocalDate localDate) {
+        return localDate.format(DOCUMENT_DATE_FORMAT);
+    }
+
+    private LocalDate getLocalDateForFieldValue(AsylumCase asylumCase, AsylumCaseDefinition field) {
+        return LocalDateTime.parse(asylumCase.read(field, String.class).orElseThrow(() -> new RequiredFieldMissingException(field.toString() + " not found."))).toLocalDate();
+    }
+
+    private LocalDate getSaHearingDate(AsylumCase asylumCase) {
+        LocalDate appealSubmissionDate = LocalDate.parse(asylumCase.read(AsylumCaseDefinition.APPEAL_SUBMISSION_DATE, String.class).orElseThrow(() -> new RequiredFieldMissingException("Appeal Submission Date is missing")));
+        return dueDateService.calculateDueDate(appealSubmissionDate.atStartOfDay(ZoneOffset.UTC), 16).toLocalDate();
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter.HoReviewEv
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter.InternalAdaDecisionsAndReasonsAllowedLetterTemplate;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter.InternalAdaSuitabilityReviewSuitableLetterTemplate;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter.InternalAdaSuitabilityReviewUnsuitableLetterTemplate;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter.UploadAppealResponseMaintainedDecisionLetterTemplate;
 
 @Configuration
 public class DocumentCreatorConfiguration {
@@ -582,6 +583,27 @@ public class DocumentCreatorConfiguration {
             documentTemplate,
             documentGenerator,
             documentUploader
+        );
+    }
+
+    @Bean("uploadTheAppealResponseLetter")
+    public DocumentCreator<AsylumCase> getUploadAppealResponseMaintainedLetterCreator(
+            @Value("${uploadAppealResponseMaintainedLetter.contentType}") String contentType,
+            @Value("${uploadAppealResponseMaintainedLetter.fileExtension}") String fileExtension,
+            @Value("${uploadAppealResponseMaintainedLetter.fileName}") String fileName,
+            AsylumCaseFileNameQualifier fileNameQualifier,
+            UploadAppealResponseMaintainedDecisionLetterTemplate documentTemplate,
+            DocumentGenerator documentGenerator,
+            DocumentUploader documentUploader
+    ) {
+        return new DocumentCreator<>(
+                contentType,
+                fileExtension,
+                fileName,
+                fileNameQualifier,
+                documentTemplate,
+                documentGenerator,
+                documentUploader
         );
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -204,6 +204,10 @@ hoReviewEvidenceLetter.fileExtension: PDF
 hoReviewEvidenceLetter.fileName: "HO-Review-Evidence-Letter"
 hoReviewEvidenceLetter.templateName: ${IA_HO_REVIEW_EVIDENCE_TEMPLATE:TB-IAC-GNO-ENG-00240.docx}
 
+uploadAppealResponseMaintainedLetter.contentType: application/pdf
+uploadAppealResponseMaintainedLetter.fileExtension: PDF
+uploadAppealResponseMaintainedLetter.fileName: "HO-Response-Letter"
+uploadAppealResponseMaintainedLetter.templateName: ${IA_HO_REVIEW_DECISION_MAINTAINED_TEMPLATE:TB-IAC-DEC-ENG-00004.docx}
 
 bailEndApplication.contentType:  application/pdf
 bailEndApplication.fileExtension: PDF
@@ -323,7 +327,9 @@ security:
       - "submitApplication"
       - "makeNewApplication"
     caseworker-ia-system:
-      - "endAppealAutomatically"
+      - "submitReasonsForAppeal"
+    caseworker-ia-homeofficelart:
+      - "uploadHomeOfficeAppealResponse"
 
 ### dependency configuration
 core_case_data_api_url: ${CCD_URL:http://127.0.0.1:4452}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -328,6 +328,7 @@ security:
       - "makeNewApplication"
     caseworker-ia-system:
       - "submitReasonsForAppeal"
+      - "endAppealAutomatically"
     caseworker-ia-homeofficelart:
       - "uploadHomeOfficeAppealResponse"
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
@@ -46,10 +46,11 @@ public class DocumentTagTest {
         assertEquals("internalAdaSuitability", DocumentTag.INTERNAL_ADA_SUITABILITY.toString());
         assertEquals("requestRespondentReview", DocumentTag.REQUEST_RESPONDENT_REVIEW.toString());
         assertEquals("internalAdaDecisionAndReasonsLetter", DocumentTag.INTERNAL_ADA_DECISION_AND_REASONS_LETTER.toString());
+        assertEquals("uploadTheAppealResponse", DocumentTag.UPLOAD_THE_APPEAL_RESPONSE.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(44, DocumentTag.values().length);
+        assertEquals(45, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
@@ -55,6 +55,6 @@ public class EventTest {
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(45, Event.values().length);
+        assertEquals(44, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
@@ -50,10 +50,11 @@ public class EventTest {
         assertEquals("uploadSignedDecisionNotice", Event.UPLOAD_SIGNED_DECISION_NOTICE.toString());
         assertEquals("unknown", Event.UNKNOWN.toString());
         assertEquals("requestCaseBuilding", Event.REQUEST_CASE_BUILDING.toString());
+        assertEquals("uploadHomeOfficeAppealResponse", Event.UPLOAD_HOME_OFFICE_APPEAL_RESPONSE.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(43, Event.values().length);
+        assertEquals(45, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
@@ -37,7 +37,7 @@ public class BundleOrderTest {
             .map(DocumentWithMetadata::getTag)
             .collect(Collectors.toList());
 
-        assertEquals(38, sortedTags.size());
+        assertEquals(39, sortedTags.size());
 
         List<DocumentTag> documentTagList = Arrays.asList(
             DocumentTag.CASE_SUMMARY,

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/UploadAppealResponseMaintainedDecisionLetterTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/UploadAppealResponseMaintainedDecisionLetterTemplateTest.java
@@ -1,0 +1,135 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.Direction;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DirectionTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.Parties;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DueDateService;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class UploadAppealResponseMaintainedDecisionLetterTemplateTest {
+
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    private final String templateName = "HO-Decision-Maintained.docx";
+    @Mock private DateProvider dateProvider;
+    @Mock private CustomerServicesProvider customerServicesProvider;
+    @Mock private DueDateService dueDateService;
+    private final Parties directionParties = Parties.RESPONDENT;
+    private final IdValue<Direction> hoReviewDirection = new IdValue<>(
+            "1",
+            new Direction(
+                    "HO Review Request Direction",
+                    directionParties,
+                    "2023-08-16",
+                    "2023-06-02",
+                    DirectionTag.RESPONDENT_REVIEW,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    "95e90870-2429-4660-b9c2-4111aff37304",
+                    "someDirectionType"
+            )
+    );
+
+    private final IdValue<Direction> requestCaseBuildingDirection = new IdValue<>(
+            "1",
+            new Direction(
+                    "Case Building Request Direction",
+                    directionParties,
+                    "2023-08-02",
+                    "2023-06-05",
+                    DirectionTag.REQUEST_CASE_BUILDING,
+                    Collections.emptyList(),
+                    Collections.emptyList(),
+                    "95e90870-2429-4660-b9c2-4111aff45604",
+                    "someDirectionType"
+            )
+    );
+
+    private UploadAppealResponseMaintainedDecisionLetterTemplate uploadAppealResponseMaintainedDecisionLetterTemplate;
+    private final String appealReferenceNumber = "RP/11111/2020";
+    private final String homeOfficeReferenceNumber = "A1234567/001";
+    private final String appellantGivenNames = "John";
+    private final String appellantFamilyName = "Doe";
+
+
+
+    @BeforeEach
+    void setUp() {
+        uploadAppealResponseMaintainedDecisionLetterTemplate =
+                new UploadAppealResponseMaintainedDecisionLetterTemplate(
+                        templateName,
+                        dateProvider,
+                        customerServicesProvider,
+                        dueDateService
+                );
+    }
+
+    @Test
+    void should_return_template_name() {
+
+        assertEquals(templateName, uploadAppealResponseMaintainedDecisionLetterTemplate.getName());
+    }
+
+    void dataSetUp() {
+        List<IdValue<Direction>> directionList = new ArrayList<>();
+        directionList.add(hoReviewDirection);
+        directionList.add(requestCaseBuildingDirection);
+        final String appealSubmissionDate = "2023-05-23";
+        final String saHearingDate = "2023-06-13";
+        final ZonedDateTime zonedDate = LocalDate.parse(appealSubmissionDate).atStartOfDay(ZoneOffset.UTC);
+        final ZonedDateTime zonedSaHEaringDate = LocalDate.parse(saHearingDate).atStartOfDay(ZoneOffset.UTC);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(APPEAL_SUBMISSION_DATE, String.class)).thenReturn(Optional.of(appealSubmissionDate));
+        when(asylumCase.read(LIST_CASE_HEARING_DATE, String.class)).thenReturn(Optional.of("2023-08-22T09:00:00.000"));
+        when(dateProvider.now()).thenReturn(LocalDate.parse("2023-06-27"));
+        when(asylumCase.read(DIRECTIONS)).thenReturn(Optional.of(directionList));
+        when(dueDateService.calculateDueDate(zonedDate, 16)).thenReturn(zonedSaHEaringDate);
+    }
+
+    @Test
+    void should_map_case_data_to_template_field_values() {
+        dataSetUp();
+
+        Map<String, Object> templateFieldValues = uploadAppealResponseMaintainedDecisionLetterTemplate.mapFieldValues(caseDetails);
+
+        assertEquals(12, templateFieldValues.size());
+        assertEquals(appealReferenceNumber, templateFieldValues.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, templateFieldValues.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, templateFieldValues.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, templateFieldValues.get("appellantFamilyName"));
+        assertEquals("2 Aug 2023", templateFieldValues.get("caseBuildingDueDate"));
+        assertEquals("13062023", templateFieldValues.get("suitabilityAssessmentHearingDate"));
+        assertEquals("22082023", templateFieldValues.get("hearingDate"));
+        assertEquals("27 Jun 2023", templateFieldValues.get("dateLetterSent"));
+    }
+}


### PR DESCRIPTION
…l Response' event

- added new user for functional test - HomeOfficeLart
- added new entity - AppealReviewOutcome.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
