### PR TITLE
RIA-7218 Allow document generation for all detained cases

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7172-ho-review-evidence-letter-document.json
+++ b/src/functionalTest/resources/scenarios/RIA-7172-ho-review-evidence-letter-document.json
@@ -10,6 +10,7 @@
         "template": "minimal-appeal-submitted.json",
         "replacements": {
           "isAdmin": "Yes",
+          "appellantInDetention": "Yes",
           "isAcceleratedDetainedAppeal": "Yes",
           "directions": [
             {
@@ -38,6 +39,7 @@
       "template": "minimal-appeal-submitted.json",
       "replacements": {
         "isAdmin": "Yes",
+        "appellantInDetention": "Yes",
         "isAcceleratedDetainedAppeal": "Yes",
         "notificationAttachmentDocuments": [
           {

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/HoReviewEvidenceLetterGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/HoReviewEvidenceLetterGenerator.java
@@ -42,7 +42,7 @@ public class HoReviewEvidenceLetterGenerator implements PreSubmitCallbackHandler
         return callback.getEvent() == Event.REQUEST_RESPONDENT_REVIEW
                 && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
                 && AsylumCaseUtils.isInternalCase(callback.getCaseDetails().getCaseData())
-                && AsylumCaseUtils.isAcceleratedDetainedAppeal(callback.getCaseDetails().getCaseData());
+                && AsylumCaseUtils.isAppellantInDetention(callback.getCaseDetails().getCaseData());
     }
 
     public PreSubmitCallbackResponse<AsylumCase> handle(


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7218

### Change description ###

- Replaced check for ADA with check for in detention to allow document to generate for both ADA and Detained Non-ADA cases

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
