### PR TITLE
RIA-7364 internal decideAnApplication letter generation

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-adjourn-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-adjourn-decision-granted-letter.json
@@ -49,7 +49,7 @@
               "document": {
                 "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
                 "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
-                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
               },
               "description": "",
               "dateUploaded": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-adjourn-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-adjourn-decision-granted-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7364 internal ADA application decided letter (Adjourn - Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 73641,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Adjourn",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-expedite-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-expedite-decision-granted-letter.json
@@ -49,7 +49,7 @@
               "document": {
                 "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
                 "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
-                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
               },
               "description": "",
               "dateUploaded": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-expedite-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-expedite-decision-granted-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7364 internal ADA application decided letter (Expedite - Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 73642,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Expedite",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-judge-review-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-judge-review-decision-granted-letter.json
@@ -49,7 +49,7 @@
               "document": {
                 "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
                 "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
-                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
               },
               "description": "",
               "dateUploaded": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-judge-review-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-judge-review-decision-granted-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7364 internal ADA application decided letter (Judges review - Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 73643,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Judge's review of Legal Officer decision",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-transfer-out-of-ada-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-transfer-out-of-ada-decision-granted-letter.json
@@ -49,7 +49,7 @@
               "document": {
                 "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
                 "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
-                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
               },
               "description": "",
               "dateUploaded": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-transfer-out-of-ada-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-ada-decide-an-application-transfer-out-of-ada-decision-granted-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7364 internal ADA application decided letter (Transfer out of ada- Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 73644,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Transfer out of accelerated detained appeals process",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-adjourn-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-adjourn-decision-granted-letter.json
@@ -48,7 +48,7 @@
               "document": {
                 "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
                 "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
-                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
               },
               "description": "",
               "dateUploaded": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-adjourn-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-adjourn-decision-granted-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7364 internal detained (non-ada) application decided letter (Adjourn - Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 73645,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Adjourn",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-expedite-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-expedite-decision-granted-letter.json
@@ -48,7 +48,7 @@
               "document": {
                 "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
                 "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
-                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
               },
               "description": "",
               "dateUploaded": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-expedite-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-expedite-decision-granted-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7364 internal detained (non-ada) application decided letter (Expedite - Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 73646,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Expedite",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-judge-review-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-judge-review-decision-granted-letter.json
@@ -48,7 +48,7 @@
               "document": {
                 "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
                 "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
-                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
               },
               "description": "",
               "dateUploaded": "{$TODAY}",

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-judge-review-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-judge-review-decision-granted-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7364 internal detained (non-ada) application decided letter (Judges review - Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 73647,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Judge's review of Legal Officer decision",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-transfer-out-of-ada-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-transfer-out-of-ada-decision-granted-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7364 internal detained (non-ada) application decided letter (Transfer out of ada - Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 73648,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Transfer out of accelerated detained appeals process",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-transfer-out-of-ada-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7364-internal-detained-decide-an-application-transfer-out-of-ada-decision-granted-letter.json
@@ -48,7 +48,7 @@
               "document": {
                 "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
                 "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
-                "document_filename": "PA 11111 2019-Gonzlez-appellant-letter-application-granted.PDF"
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
               },
               "description": "",
               "dateUploaded": "{$TODAY}",

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/AsylumCaseDefinition.java
@@ -555,7 +555,13 @@ public enum AsylumCaseDefinition {
             "remissionDecision", new TypeReference<RemissionDecision>(){}),
 
     REASON_APPEAL_MARKED_AS_ADA(
-            "reasonAppealMarkedAsAda", new TypeReference<String>(){});
+            "reasonAppealMarkedAsAda", new TypeReference<String>(){}),
+
+    MAKE_AN_APPLICATIONS(
+            "makeAnApplications", new TypeReference<List<IdValue<MakeAnApplication>>>(){}),
+
+    DECIDE_AN_APPLICATION_ID(
+            "decideAnApplicationId", new TypeReference<String>(){});
 
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
@@ -54,6 +54,7 @@ public enum DocumentTag {
     INTERNAL_DETAINED_REQUEST_HO_RESPONSE_REVIEW("internalDetainedRequestHomeOfficeResponseReview", CaseType.ASYLUM),
     INTERNAL_DETAINED_EDIT_CASE_LISTING_LETTER("internalDetainedEditCaseListingLetter", CaseType.ASYLUM),
     INTERNAL_DET_MARK_AS_ADA_LETTER("internalDetMarkAsAdaLetter", CaseType.ASYLUM),
+    INTERNAL_DECIDE_AN_APPLICATION_LETTER("internalDecideAnApplicationLetter", CaseType.ASYLUM),
     BAIL_SUBMISSION("bailSubmission", CaseType.BAIL),
     BAIL_EVIDENCE("uploadTheBailEvidenceDocs", CaseType.BAIL),
     BAIL_DECISION_UNSIGNED("bailDecisionUnsigned", CaseType.BAIL),

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/MakeAnApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/MakeAnApplication.java
@@ -1,0 +1,130 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+
+@EqualsAndHashCode
+@ToString
+public class MakeAnApplication {
+
+    private String type;
+    private String details;
+    private List<IdValue<Document>> evidence;
+    private String applicant;
+    private String date;
+    private String decision;
+    private String state;
+    private String applicantRole;
+    private String decisionReason;
+    private String decisionDate;
+    private String decisionMaker;
+
+    public MakeAnApplication() {
+
+    }
+
+    public MakeAnApplication(
+            String applicant,
+            String type,
+            String details,
+            List<IdValue<Document>> evidence,
+            String date,
+            String decision,
+            String state,
+            String applicantRole) {
+        requireNonNull(applicant);
+        requireNonNull(type);
+        requireNonNull(details);
+        requireNonNull(evidence);
+        requireNonNull(date);
+        requireNonNull(decision);
+        requireNonNull(state);
+        requireNonNull(applicantRole);
+
+        this.applicant = applicant;
+        this.type = type;
+        this.details = details;
+        this.evidence = evidence;
+        this.date = date;
+        this.decision = decision;
+        this.state = state;
+        this.applicantRole = applicantRole;
+    }
+
+    public String getType() {
+        requireNonNull(type);
+        return type;
+    }
+
+    public String getDetails() {
+        requireNonNull(details);
+        return details;
+    }
+
+    public List<IdValue<Document>> getEvidence() {
+        requireNonNull(evidence);
+        return evidence;
+    }
+
+    public String getApplicant() {
+        requireNonNull(applicant);
+        return applicant;
+    }
+
+    public String getDate() {
+        requireNonNull(date);
+        return date;
+    }
+
+    public String getDecision() {
+        requireNonNull(decision);
+        return decision;
+    }
+
+    public String getState() {
+        requireNonNull(state);
+        return state;
+    }
+
+    public String getApplicantRole() {
+        requireNonNull(applicantRole);
+        return applicantRole;
+    }
+
+    public void setDecision(String decision) {
+        requireNonNull(decision);
+        this.decision = decision;
+    }
+
+    public void setDecisionReason(String decisionReason) {
+        requireNonNull(decisionReason);
+        this.decisionReason = decisionReason;
+    }
+
+    public void setDecisionDate(String decisionDate) {
+        requireNonNull(decisionDate);
+        this.decisionDate = decisionDate;
+    }
+
+    public void setDecisionMaker(String decisionMaker) {
+        requireNonNull(decisionMaker);
+        this.decisionMaker = decisionMaker;
+    }
+
+    public String getDecisionReason() {
+        return decisionReason;
+    }
+
+    public String getDecisionDate() {
+        return decisionDate;
+    }
+
+    public String getDecisionMaker() {
+        return decisionMaker;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/MakeAnApplicationTypes.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/MakeAnApplicationTypes.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities;
+
+import static java.util.Arrays.stream;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Optional;
+
+public enum  MakeAnApplicationTypes {
+
+    ADJOURN("Adjourn"),
+    EXPEDITE("Expedite"),
+    JUDGE_REVIEW("Judge's review of application decision"),
+    JUDGE_REVIEW_LO("Judge's review of Legal Officer decision"),
+    LINK_OR_UNLINK("Link/unlink appeals"),
+    TIME_EXTENSION("Time extension"),
+    TRANSFER("Transfer"),
+    WITHDRAW("Withdraw"),
+    UPDATE_HEARING_REQUIREMENTS("Update hearing requirements"),
+    UPDATE_APPEAL_DETAILS("Update appeal details"),
+    REINSTATE("Reinstate an ended appeal"),
+    TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS("Transfer out of accelerated detained appeals process"),
+    OTHER("Other");
+
+    MakeAnApplicationTypes(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    private final String value;
+
+    public static Optional<MakeAnApplicationTypes> from(
+            String value
+    ) {
+        return stream(values())
+                .filter(v -> v.getValue().equals(value))
+                .findFirst();
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}
+
+

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
@@ -49,6 +49,7 @@ public enum Event {
     RECORD_REMISSION_DECISION("recordRemissionDecision", CaseType.ASYLUM),
     REQUEST_RESPONSE_REVIEW("requestResponseReview", CaseType.ASYLUM),
     MARK_APPEAL_AS_ADA("markAppealAsAda", CaseType.ASYLUM),
+    DECIDE_AN_APPLICATION("decideAnApplication", CaseType.ASYLUM),
     SUBMIT_APPLICATION("submitApplication", CaseType.BAIL),
     RECORD_THE_DECISION("recordTheDecision", CaseType.BAIL),
     END_APPLICATION("endApplication", CaseType.BAIL),

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/State.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/State.java
@@ -26,6 +26,9 @@ public enum State {
     CMA_ADJUSTMENTS_AGREED("cmaAdjustmentsAgreed"),
     FTPA_DECIDED("ftpaDecided"),
     PENDING_PAYMENT("pendingPayment"),
+    ADJOURNED("adjourned"),
+    FTPA_SUBMITTED("ftpaSubmitted"),
+
 
 
 

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterHandler.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit.letter;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.*;
+
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.MakeAnApplicationService;
+
+
+@Component
+public class InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final DocumentCreator<AsylumCase> internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter;
+    private final DocumentHandler documentHandler;
+    private final MakeAnApplicationService makeAnApplicationService;
+    private final String decisionGranted = "Granted";
+
+    public InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterHandler(
+            @Qualifier("internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter") DocumentCreator<AsylumCase> internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter,
+            DocumentHandler documentHandler,
+            MakeAnApplicationService makeAnApplicationService
+    ) {
+        this.internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter = internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter;
+        this.documentHandler = documentHandler;
+        this.makeAnApplicationService = makeAnApplicationService;
+    }
+
+    public boolean canHandle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        Optional<MakeAnApplication> optionalMakeAnApplication = makeAnApplicationService.getMakeAnApplication(asylumCase, true);
+        if (!optionalMakeAnApplication.isPresent()) {
+            return false;
+        }
+        boolean applicationGranted = optionalMakeAnApplication.get().getDecision().equals(decisionGranted);
+
+        return callback.getEvent() == Event.DECIDE_AN_APPLICATION
+                && callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+                && isInternalCase(asylumCase)
+                && isAppellantInDetention(asylumCase)
+                && applicationGranted;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+            PreSubmitCallbackStage callbackStage,
+            Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        Document applicationGrantedLetter = internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.create(caseDetails);
+        documentHandler.addWithMetadata(
+                asylumCase,
+                applicationGrantedLetter,
+                NOTIFICATION_ATTACHMENT_DOCUMENTS,
+                DocumentTag.INTERNAL_DECIDE_AN_APPLICATION_LETTER
+        );
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
@@ -144,6 +144,9 @@ public class BundleOrder implements Comparator<DocumentWithMetadata> {
             case INTERNAL_DET_MARK_AS_ADA_LETTER:
                 log.warn("INTERNAL_DET_MARK_AS_ADA_LETTER tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
                 return 48;
+            case INTERNAL_DECIDE_AN_APPLICATION_LETTER:
+                log.warn("INTERNAL_DECIDE_AN_APPLICATION_LETTER tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
+                return 49;
             default:
                 throw new IllegalStateException("document has unknown tag: " + document.getTag() + ", description: " + document.getDescription());
         }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate.java
@@ -1,0 +1,98 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.getAppellantPersonalisation;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.util.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.DocumentTemplate;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.MakeAnApplicationService;
+
+@Component
+public class InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate implements DocumentTemplate<AsylumCase> {
+
+    private static final String DECISION_GRANTED = "Granted";
+    private static final String timeExtentionContent = "The Tribunal will give you more time to complete your next task. You will get a notification with the new date soon.";
+    private static final String adjournExpediteTransferOrUpdateHearingReqsContent = "The details of your hearing will be updated. The Tribunal will contact you when this happens.";
+    private static final String judgesReviewContent = "The decision on your original request will be overturned. The Tribunal will contact you if there is something you need to do next.";
+    private static final String linkOrUnlinkContent = "This appeal will be linked or unlinked. The Tribunal will contact you when this happens.";
+    private static final String withdrawnContent = "The Tribunal will end the appeal. The Tribunal will contact you when this happens.";
+    private static final String updateUpdateDetailsOrOtherContent = "The Tribunal will contact you when it makes the changes you requested.";
+    private static final String transferOutOfAdaContent = "Your appeal will continue but will no longer be decided within 25 working days. The Tribunal will change the date of your hearing. The Tribunal will contact you with a new date for your hearing and to tell you what will happen next with your appeal.";
+    private final String templateName;
+    private final DateProvider dateProvider;
+    private final CustomerServicesProvider customerServicesProvider;
+    private final MakeAnApplicationService makeAnApplicationService;
+
+
+    public InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate(
+            @Value("${internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.templateName}") String templateName,
+            DateProvider dateProvider,
+            CustomerServicesProvider customerServicesProvider,
+            MakeAnApplicationService makeAnApplicationService) {
+        this.templateName = templateName;
+        this.dateProvider = dateProvider;
+        this.customerServicesProvider = customerServicesProvider;
+        this.makeAnApplicationService = makeAnApplicationService;
+    }
+
+    public String getName() {
+        return templateName;
+    }
+
+    public Map<String, Object> mapFieldValues(
+            CaseDetails<AsylumCase> caseDetails
+    ) {
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+        final Map<String, Object> fieldValues = new HashMap<>();
+
+        Optional<MakeAnApplication> optionalMakeAnApplication = getMakeAnApplication(asylumCase);
+
+        String applicationType = "";
+        String applicationDecision = "";
+        String applicationDecisionReason = "No reason given";
+        if (optionalMakeAnApplication.isPresent()) {
+            MakeAnApplication makeAnApplication = optionalMakeAnApplication.get();
+            applicationType = makeAnApplication.getType();
+            applicationDecision = makeAnApplication.getDecision();
+            applicationDecisionReason = makeAnApplication.getDecisionReason();
+        }
+
+        boolean applicationGranted = DECISION_GRANTED.equals(applicationDecision);
+
+        fieldValues.putAll(getAppellantPersonalisation(asylumCase));
+        fieldValues.put("dateLetterSent", formatDateForNotificationAttachmentDocument(dateProvider.now()));
+        fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase));
+        fieldValues.put("customerServicesEmail", customerServicesProvider.getInternalCustomerServicesEmail(asylumCase));
+        fieldValues.put("applicationType", applicationType);
+        fieldValues.put("applicationReason", applicationDecisionReason);
+        fieldValues.put("whatHappensNextContent", getWhatHappensNextContent(MakeAnApplicationTypes.from(applicationType).get()));
+
+
+        return fieldValues;
+    }
+
+    private Optional<MakeAnApplication> getMakeAnApplication(AsylumCase asylumCase) {
+        return makeAnApplicationService.getMakeAnApplication(asylumCase, true);
+    }
+
+    private String getWhatHappensNextContent(MakeAnApplicationTypes makeAnApplicationTypes) {
+        return switch (makeAnApplicationTypes) {
+            case TIME_EXTENSION -> timeExtentionContent;
+            case ADJOURN, EXPEDITE, TRANSFER, UPDATE_HEARING_REQUIREMENTS -> adjournExpediteTransferOrUpdateHearingReqsContent;
+            case JUDGE_REVIEW, JUDGE_REVIEW_LO -> judgesReviewContent;
+            case LINK_OR_UNLINK -> linkOrUnlinkContent;
+            case WITHDRAW -> withdrawnContent;
+            case UPDATE_APPEAL_DETAILS, OTHER -> updateUpdateDetailsOrOtherContent;
+            case TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS -> transferOutOfAdaContent;
+            default -> "Unknown";
+        };
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/MakeAnApplicationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/MakeAnApplicationService.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure;
+
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.DECIDE_AN_APPLICATION_ID;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.ADJOURN;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.EXPEDITE;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.JUDGE_REVIEW;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.LINK_OR_UNLINK;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.OTHER;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.REINSTATE;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.TIME_EXTENSION;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.TRANSFER;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.UPDATE_APPEAL_DETAILS;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.UPDATE_HEARING_REQUIREMENTS;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes.WITHDRAW;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+
+@Service
+public class MakeAnApplicationService {
+
+    private static final Map<String,String> APPLICATION_PHRASE = Map.ofEntries(
+            Map.entry(ADJOURN.toString(), "change the hearing date"),
+            Map.entry(EXPEDITE.toString(), "have the hearing sooner"),
+            Map.entry(JUDGE_REVIEW.toString(), "ask a judge to review the decision"),
+            Map.entry(LINK_OR_UNLINK.toString(), "link or unlink the appeal"),
+            Map.entry(TIME_EXTENSION.toString(), "ask for more time"),
+            Map.entry(TRANSFER.toString(), "move the hearing to a different location"),
+            Map.entry(WITHDRAW.toString(), "withdraw from the appeal"),
+            Map.entry(UPDATE_HEARING_REQUIREMENTS.toString(), "change some of the hearing requirements"),
+            Map.entry(UPDATE_APPEAL_DETAILS.toString(), "change some of the appeal details"),
+            Map.entry(REINSTATE.toString(), "reinstate the appeal"),
+            Map.entry(OTHER.toString(), "change something about the appeal")
+    );
+
+    public Optional<MakeAnApplication> getMakeAnApplication(AsylumCase asylumCase, boolean decided) {
+        Optional<MakeAnApplication> makeApplicationOptional = Optional.empty();
+        Optional<List<IdValue<MakeAnApplication>>> makeAnApplicationsOptional = asylumCase.read(AsylumCaseDefinition.MAKE_AN_APPLICATIONS);
+        if (makeAnApplicationsOptional.isPresent()) {
+            List<IdValue<MakeAnApplication>> idValues = makeAnApplicationsOptional.orElse(Collections.emptyList());
+            if (idValues.size() > 0) {
+                if (decided) {
+                    Optional<String>  decideAnApplicationIdOptional = asylumCase.read(DECIDE_AN_APPLICATION_ID);
+                    String decideAnApplicationId = decideAnApplicationIdOptional.orElse("");
+                    makeApplicationOptional = idValues.stream().filter(idValue -> idValue.getId().equals(decideAnApplicationId)).map(idValue -> idValue.getValue()).findAny();
+                } else {
+                    int targetIndex = Collections.max(idValues.stream().map(idValue -> Integer.parseInt(idValue.getId())).collect(Collectors.toList()));
+                    makeApplicationOptional = idValues.stream().filter(idValue -> idValue.getId().equals(String.valueOf(targetIndex))).map(idValue -> idValue.getValue()).findAny();
+                }
+            }
+        }
+        return makeApplicationOptional;
+    }
+
+    public boolean isApplicationListed(State state) {
+        if (Arrays.asList(
+                State.ADJOURNED,
+                State.PREPARE_FOR_HEARING,
+                State.FINAL_BUNDLING,
+                State.PRE_HEARING,
+                State.DECISION,
+                State.DECIDED,
+                State.FTPA_SUBMITTED,
+                State.FTPA_DECIDED
+        ).contains(state)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public String mapApplicationTypeToPhrase(MakeAnApplication application) {
+        return APPLICATION_PHRASE.get(application.getType());
+    }
+}
+

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
@@ -960,4 +960,25 @@ public class DocumentCreatorConfiguration {
                 documentUploader
         );
     }
+
+    @Bean("internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter")
+    public DocumentCreator<AsylumCase> getinternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterCreator(
+            @Value("${internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.contentType}") String contentType,
+            @Value("${internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.fileExtension}") String fileExtension,
+            @Value("${internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.fileName}") String fileName,
+            AsylumCaseFileNameQualifier fileNameQualifier,
+            InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate documentTemplate,
+            DocumentGenerator documentGenerator,
+            DocumentUploader documentUploader
+    ) {
+        return new DocumentCreator<>(
+                contentType,
+                fileExtension,
+                fileName,
+                fileNameQualifier,
+                documentTemplate,
+                documentGenerator,
+                documentUploader
+        );
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -299,6 +299,11 @@ internalMarkAppealAsAda.fileExtension: PDF
 internalMarkAppealAsAda.fileName: "detained-appellant-mark-as-ada-notice"
 internalMarkAppealAsAda.templateName: ${IA_INTERNAL_MARK_APPEAL_AS_ADA_TEMPLATE:TB-IAC-LET-ENG-00008.docx}
 
+internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.contentType: application/pdf
+internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.fileExtension: PDF
+internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.fileName: "appellant-letter-application-granted"
+internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.templateName: ${IA_INTERNAL_DETAINED_AND_ADA_DECIDE_AN_APPLICATION_DECISION_GRANTED_LETTER_TEMPLATE:TB-IAC-LET-ENG-00015.docx}
+
 ccdGatewayUrl: ${CCD_GW_URL:http://localhost:3453}
 
 docmosis.accessKey: ${DOCMOSIS_ACCESS_KEY}
@@ -374,6 +379,7 @@ security:
       - "requestResponseReview"
       - "requestHearingRequirementsFeature"
       - "markAppealAsAda"
+      - "decideAnApplication"
     caseworker-ia-admofficer:
       - "listCase"
       - "submitAppeal"
@@ -420,6 +426,7 @@ security:
       - "uploadSignedDecisionNotice"
       - "adaSuitabilityReview"
       - "generateHearingBundle"
+      - "decideAnApplication"
     caseworker-ia-homeofficebail:
       - "submitApplication"
       - "makeNewApplication"

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
@@ -57,10 +57,11 @@ public class DocumentTagTest {
         assertEquals("internalDetainedRequestHomeOfficeResponseReview", DocumentTag.INTERNAL_DETAINED_REQUEST_HO_RESPONSE_REVIEW.toString());
         assertEquals("internalDetainedEditCaseListingLetter", DocumentTag.INTERNAL_DETAINED_EDIT_CASE_LISTING_LETTER.toString());
         assertEquals("internalDetMarkAsAdaLetter", DocumentTag.INTERNAL_DET_MARK_AS_ADA_LETTER.toString());
+        assertEquals("internalDecideAnApplicationLetter", DocumentTag.INTERNAL_DECIDE_AN_APPLICATION_LETTER.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(56, DocumentTag.values().length);
+        assertEquals(57, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/MakeAnApplicationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/MakeAnApplicationTest.java
@@ -1,0 +1,95 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+
+
+@ExtendWith(MockitoExtension.class)
+public class MakeAnApplicationTest {
+
+    private final String type = "Adjourn";
+    private final String details = "Some application text";
+    private final List<IdValue<Document>> evidence = Collections.emptyList();
+    private final String applicant = "Legal representative";
+    private final String date = "2020-09-21";
+    private final String decision = "Pending";
+    private final String state = "LISTING";
+    private final String applicantRole = UserRole.LEGAL_REPRESENTATIVE.toString();
+
+    public MakeAnApplication makeAnApplication =
+            new MakeAnApplication(
+                    applicant,
+                    type,
+                    details,
+                    evidence,
+                    date,
+                    decision,
+                    state,
+                    applicantRole
+            );
+
+    @Test
+    public void should_hold_onto_values() {
+        assertEquals(type, makeAnApplication.getType());
+        assertEquals(details, makeAnApplication.getDetails());
+        assertEquals(evidence, makeAnApplication.getEvidence());
+        assertEquals(applicant, makeAnApplication.getApplicant());
+        assertEquals(date, makeAnApplication.getDate());
+        assertEquals(decision, makeAnApplication.getDecision());
+        assertEquals(state, makeAnApplication.getState());
+        assertEquals(applicantRole, makeAnApplication.getApplicantRole());
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> new MakeAnApplication(
+                null, type, details, evidence,
+                date, decision, state, applicantRole))
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new MakeAnApplication(
+                applicant, null, details, evidence,
+                date, decision, state, applicantRole))
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new MakeAnApplication(
+                applicant, type, null, evidence,
+                date, decision, state, applicantRole))
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new MakeAnApplication(
+                applicant, type, details, null,
+                date, decision, state, applicantRole))
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new MakeAnApplication(
+                applicant, type, details, evidence,
+                null, decision, state, applicantRole))
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new MakeAnApplication(
+                applicant, type, details, evidence,
+                date, null, state, applicantRole))
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new MakeAnApplication(
+                applicant, type, details, evidence,
+                date, decision, null, applicantRole))
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> new MakeAnApplication(
+                applicant, type, details, evidence,
+                date, decision, state, null))
+                .isExactlyInstanceOf(NullPointerException.class);
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/MakeAnApplicationTypesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/MakeAnApplicationTypesTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class MakeAnApplicationTypesTest {
+
+    @Test
+    void has_correct_values() {
+        assertEquals("Adjourn", MakeAnApplicationTypes.ADJOURN.toString());
+        assertEquals("Expedite", MakeAnApplicationTypes.EXPEDITE.toString());
+        assertEquals("Link/unlink appeals", MakeAnApplicationTypes.LINK_OR_UNLINK.toString());
+        assertEquals("Judge's review of application decision", MakeAnApplicationTypes.JUDGE_REVIEW.toString());
+        assertEquals("Judge's review of Legal Officer decision", MakeAnApplicationTypes.JUDGE_REVIEW_LO.toString());
+        assertEquals("Time extension", MakeAnApplicationTypes.TIME_EXTENSION.toString());
+        assertEquals("Transfer", MakeAnApplicationTypes.TRANSFER.toString());
+        assertEquals("Withdraw", MakeAnApplicationTypes.WITHDRAW.toString());
+        assertEquals("Update hearing requirements", MakeAnApplicationTypes.UPDATE_HEARING_REQUIREMENTS.toString());
+        assertEquals("Update appeal details", MakeAnApplicationTypes.UPDATE_APPEAL_DETAILS.toString());
+        assertEquals("Reinstate an ended appeal", MakeAnApplicationTypes.REINSTATE.toString());
+        assertEquals("Transfer out of accelerated detained appeals process",
+                MakeAnApplicationTypes.TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS.toString());
+        assertEquals("Other", MakeAnApplicationTypes.OTHER.toString());
+    }
+
+    @Test
+    void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
+        assertEquals(13, MakeAnApplicationTypes.values().length);
+    }
+}
+
+

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
@@ -56,10 +56,11 @@ public class EventTest {
         assertEquals("recordRemissionDecision", Event.RECORD_REMISSION_DECISION.toString());
         assertEquals("requestHearingRequirementsFeature", Event.REQUEST_HEARING_REQUIREMENTS_FEATURE.toString());
         assertEquals("markAppealAsAda", Event.MARK_APPEAL_AS_ADA.toString());
+        assertEquals("decideAnApplication", Event.DECIDE_AN_APPLICATION.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(51, Event.values().length);
+        assertEquals(52, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/StateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/StateTest.java
@@ -29,11 +29,13 @@ public class StateTest {
         assertEquals("awaitingCmaRequirements", State.AWAITING_CMA_REQUIREMENTS.toString());
         assertEquals("cmaAdjustmentsAgreed", State.CMA_ADJUSTMENTS_AGREED.toString());
         assertEquals("pendingPayment", State.PENDING_PAYMENT.toString());
+        assertEquals("adjourned", State.ADJOURNED.toString());
+        assertEquals("ftpaSubmitted", State.FTPA_SUBMITTED.toString());
 
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(22, State.values().length);
+        assertEquals(24, State.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterHandlerTest.java
@@ -1,0 +1,262 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit.letter;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.MakeAnApplicationService;
+
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterHandlerTest {
+
+
+    @Mock
+    private DocumentCreator<AsylumCase> internalApplicationDecidedLetterCreator;
+    @Mock
+    private DocumentHandler documentHandler;
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private Document uploadedDocument;
+    @Mock
+    private MakeAnApplicationService makeAnApplicationService;
+    private final YesOrNo yes = YesOrNo.YES;
+    private final String decisionGranted = "Granted";
+    private final String decisionRefused = "Refused";
+    private final String decisionPending = "Pending";
+    private List<IdValue<MakeAnApplication>> makeAnApplications = new ArrayList<>();
+    private final MakeAnApplication makeAnApplication = new MakeAnApplication(
+            "Admin Officer",
+            MakeAnApplicationTypes.ADJOURN.getValue(),
+            "someRandomDetails",
+            new ArrayList<>(),
+            LocalDate.now().toString(),
+            decisionGranted,
+            State.APPEAL_SUBMITTED.toString(),
+            "caseworker-ia-admofficer");
+    private InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterHandler internalDecideAnApplicationLetterHandler;
+
+    @BeforeEach
+    public void setUp() {
+        internalDecideAnApplicationLetterHandler =
+                new InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterHandler(
+                        internalApplicationDecidedLetterCreator,
+                        documentHandler,
+                        makeAnApplicationService
+                );
+
+        when(caseDetails.getState()).thenReturn(State.APPEAL_SUBMITTED);
+        when(callback.getEvent()).thenReturn(Event.DECIDE_AN_APPLICATION);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(yes));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(yes));
+
+        makeAnApplications.add(new IdValue<>("1", makeAnApplication));
+        when(asylumCase.read(MAKE_AN_APPLICATIONS)).thenReturn(Optional.of(makeAnApplications));
+        when(asylumCase.read(DECIDE_AN_APPLICATION_ID)).thenReturn(Optional.of("1"));
+
+        when(makeAnApplicationService.getMakeAnApplication(asylumCase, true)).thenReturn(Optional.of(makeAnApplication));
+    }
+
+    @Test // change
+    public void should_create_application_decided_letter_and_append_to_notification_attachment_documents() {
+
+        when(internalApplicationDecidedLetterCreator.create(caseDetails)).thenReturn(uploadedDocument);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                internalDecideAnApplicationLetterHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(documentHandler, times(1)).addWithMetadata(asylumCase, uploadedDocument, NOTIFICATION_ATTACHMENT_DOCUMENTS, DocumentTag.INTERNAL_DECIDE_AN_APPLICATION_LETTER);
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        assertThatThrownBy(() -> internalDecideAnApplicationLetterHandler.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        assertThatThrownBy(() -> internalDecideAnApplicationLetterHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+                .hasMessage("Cannot handle callback")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void it_cannot_handle_callback_if_is_admin_is_missing_or_set_to_no() {
+        //isAdmin defaults to false if not present
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+            when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.empty());
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = internalDecideAnApplicationLetterHandler.canHandle(callbackStage, callback);
+                assertFalse(canHandle);
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void it_cannot_handle_callback_if_is_detained_is_missing_or_set_to_no() {
+        //isDetained defaults to false if not present
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+            when(callback.getCaseDetails().getCaseData().read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.empty());
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = internalDecideAnApplicationLetterHandler.canHandle(callbackStage, callback);
+                assertFalse(canHandle);
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    public void it_should_only_handle_about_to_submit_and_decide_an_application_event() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = internalDecideAnApplicationLetterHandler.canHandle(callbackStage, callback);
+
+                if (callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT && callback.getEvent().equals(Event.DECIDE_AN_APPLICATION)) {
+                    assertTrue(canHandle);
+                } else {
+                    assertFalse(canHandle);
+                }
+            }
+            reset(callback);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(YesOrNo.class)
+    public void it_should_only_handle_internal_cases(YesOrNo yesOrNo) {
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(yesOrNo));
+
+        boolean canHandle = internalDecideAnApplicationLetterHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        if (yesOrNo == yes) {
+            assertTrue(canHandle);
+        } else {
+            assertFalse(canHandle);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(YesOrNo.class)
+    public void it_should_handle_both_internal_detained_cases_and_internal_ada_cases(YesOrNo yesOrNo) {
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(yesOrNo));
+
+        boolean canHandle = internalDecideAnApplicationLetterHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertTrue(canHandle);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {decisionGranted, decisionRefused, decisionPending})
+    public void it_should_only_handle_granted_applications(String decision) {
+        List<IdValue<MakeAnApplication>> testApplications = new ArrayList<>();
+
+        MakeAnApplication testApplication = new MakeAnApplication(
+                "Admin Officer",
+                MakeAnApplicationTypes.ADJOURN.getValue(),
+                "someRandomDetails",
+                new ArrayList<>(),
+                LocalDate.now().toString(),
+                decision.toString(),
+                State.APPEAL_SUBMITTED.toString(),
+                "caseworker-ia-admofficer");
+
+        testApplications.add(new IdValue<>("1", testApplication));
+
+        when(asylumCase.read(MAKE_AN_APPLICATIONS)).thenReturn(Optional.of(testApplications));
+        when(asylumCase.read(DECIDE_AN_APPLICATION_ID)).thenReturn(Optional.of("1"));
+        when(makeAnApplicationService.getMakeAnApplication(asylumCase, true)).thenReturn(Optional.of(testApplication));
+
+        boolean canHandle = internalDecideAnApplicationLetterHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+        
+        if (decision.equals(decisionGranted.toString())) {
+            assertTrue(canHandle);
+        } else {
+            assertFalse(canHandle);
+        }
+    }
+
+    @Test
+    public void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> internalDecideAnApplicationLetterHandler.canHandle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> internalDecideAnApplicationLetterHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> internalDecideAnApplicationLetterHandler.handle(null, callback))
+                .hasMessage("callbackStage must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> internalDecideAnApplicationLetterHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+                .hasMessage("callback must not be null")
+                .isExactlyInstanceOf(NullPointerException.class);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
@@ -37,7 +37,7 @@ public class BundleOrderTest {
             .map(DocumentWithMetadata::getTag)
             .collect(Collectors.toList());
 
-        assertEquals(50, sortedTags.size());
+        assertEquals(51, sortedTags.size());
 
         List<DocumentTag> documentTagList = Arrays.asList(
             DocumentTag.CASE_SUMMARY,

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplateTest.java
@@ -1,0 +1,137 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.time.LocalDate;
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.MakeAnApplicationService;
+
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplateTest {
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private DateProvider dateProvider;
+    @Mock
+    private CustomerServicesProvider customerServicesProvider;
+    @Mock
+    private MakeAnApplicationService makeAnApplicationService;
+    private final String templateName = "TB-IAC-DEC-ENG-00015.docx";
+    private final String timeExtentionContent = "The Tribunal will give you more time to complete your next task. You will get a notification with the new date soon.";
+    private final String adjournExpediteTransferOrUpdateHearingReqsContent = "The details of your hearing will be updated. The Tribunal will contact you when this happens.";
+    private final String judgesReviewContent = "The decision on your original request will be overturned. The Tribunal will contact you if there is something you need to do next.";
+    private final String linkOrUnlinkContent = "This appeal will be linked or unlinked. The Tribunal will contact you when this happens.";
+    private final String withdrawnContent = "The Tribunal will end the appeal. The Tribunal will contact you when this happens.";
+    private final String updateUpdateDetailsOrOtherContent = "The Tribunal will contact you when it makes the changes you requested.";
+    private final String transferOutOfAdaContent = "Your appeal will continue but will no longer be decided within 25 working days. The Tribunal will change the date of your hearing. The Tribunal will contact you with a new date for your hearing and to tell you what will happen next with your appeal.";
+    private final String internalAdaCustomerServicesTelephoneNumber = "0300 123 1234";
+    private final String internalAdaCustomerServicesEmailAddress = "example@email.com";
+    private final String appealReferenceNumber = "RP/11111/2020";
+    private final String homeOfficeReferenceNumber = "A1234567/001";
+    private final String appellantGivenNames = "John";
+    private final String appellantFamilyName = "Doe";
+    private InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate;
+
+    @BeforeEach
+    void setUp() {
+        internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate =
+                new InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate(
+                        templateName,
+                        dateProvider,
+                        customerServicesProvider,
+                        makeAnApplicationService
+                );
+    }
+
+    void dataSetup() {
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        when(customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase))
+                .thenReturn(internalAdaCustomerServicesTelephoneNumber);
+        when(customerServicesProvider.getInternalCustomerServicesEmail(asylumCase))
+                .thenReturn(internalAdaCustomerServicesEmailAddress);
+
+        when(dateProvider.now()).thenReturn(LocalDate.now());
+    }
+
+    @Test
+    void should_return_template_name() {
+        assertEquals(templateName, internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate.getName());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MakeAnApplicationTypes.class)
+    void should_map_case_data_to_template_field_values(MakeAnApplicationTypes makeAnApplicationTypes) {
+        dataSetup();
+        List<IdValue<MakeAnApplication>> makeAnApplications = new ArrayList<>();
+        final MakeAnApplication testApplication = new MakeAnApplication(
+                "Admin Officer",
+                makeAnApplicationTypes.getValue(),
+                "someRandomDetails",
+                new ArrayList<>(),
+                LocalDate.now().toString(),
+                "Granted",
+                State.APPEAL_SUBMITTED.toString(),
+                "caseworker-ia-admofficer");
+        makeAnApplications.add(new IdValue<>("1", testApplication));
+        
+        when(asylumCase.read(MAKE_AN_APPLICATIONS)).thenReturn(Optional.of(makeAnApplications));
+        when(asylumCase.read(DECIDE_AN_APPLICATION_ID)).thenReturn(Optional.of("1"));
+
+        when(makeAnApplicationService.getMakeAnApplication(asylumCase, true)).thenReturn(Optional.of(testApplication));
+
+        Map<String, Object> templateFieldValues = internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate.mapFieldValues(caseDetails);
+
+        assertEquals(11, templateFieldValues.size());
+        assertEquals("[userImage:hmcts.png]", templateFieldValues.get("hmcts"));
+        assertEquals(appealReferenceNumber, templateFieldValues.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, templateFieldValues.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, templateFieldValues.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, templateFieldValues.get("appellantFamilyName"));
+        assertEquals(internalAdaCustomerServicesTelephoneNumber, templateFieldValues.get("customerServicesTelephone"));
+        assertEquals(internalAdaCustomerServicesEmailAddress, templateFieldValues.get("customerServicesEmail"));
+        assertEquals(formatDateForNotificationAttachmentDocument(dateProvider.now()), templateFieldValues.get("dateLetterSent"));
+        assertEquals(testApplication.getType(), templateFieldValues.get("applicationType"));
+        assertEquals(testApplication.getDecisionReason(), templateFieldValues.get("applicationReason"));
+
+        switch (makeAnApplicationTypes) {
+            case TIME_EXTENSION -> assertEquals(timeExtentionContent, templateFieldValues.get("whatHappensNextContent"));
+            case ADJOURN, EXPEDITE, TRANSFER, UPDATE_HEARING_REQUIREMENTS -> assertEquals(adjournExpediteTransferOrUpdateHearingReqsContent, templateFieldValues.get("whatHappensNextContent"));
+            case JUDGE_REVIEW, JUDGE_REVIEW_LO -> assertEquals(judgesReviewContent, templateFieldValues.get("whatHappensNextContent"));
+            case LINK_OR_UNLINK -> assertEquals(linkOrUnlinkContent, templateFieldValues.get("whatHappensNextContent"));
+            case WITHDRAW -> assertEquals(withdrawnContent, templateFieldValues.get("whatHappensNextContent"));
+            case UPDATE_APPEAL_DETAILS, OTHER -> assertEquals(updateUpdateDetailsOrOtherContent, templateFieldValues.get("whatHappensNextContent"));
+            case TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS -> assertEquals(transferOutOfAdaContent, templateFieldValues.get("whatHappensNextContent"));
+            default -> assertEquals(true, true);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/MakeAnApplicationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/MakeAnApplicationServiceTest.java
@@ -1,0 +1,146 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.DECIDE_AN_APPLICATION_ID;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.MAKE_AN_APPLICATIONS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class MakeAnApplicationServiceTest {
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private List<IdValue<MakeAnApplication>> applications;
+    @Mock
+    private MakeAnApplication makeAnApplication;
+
+    private MakeAnApplicationService makeAnApplicationService;
+    private String decideAnApplicationId = "2";
+
+    @BeforeEach
+    public void setup() {
+        List<IdValue<MakeAnApplication>> makeAnApplications = new ArrayList<>();
+        MakeAnApplication makeAnApplication1 = new MakeAnApplication(
+                "",
+                "Expedite",
+                "",
+                new ArrayList<>(),
+                "",
+                "",
+                "",
+                "");
+        makeAnApplications.add(new IdValue<>("1", makeAnApplication1));
+        MakeAnApplication makeAnApplication2 = new MakeAnApplication(
+                "",
+                "Other",
+                "",
+                new ArrayList<>(),
+                "",
+                "",
+                "",
+                "");
+        makeAnApplications.add(new IdValue<>("2", makeAnApplication2));
+        MakeAnApplication makeAnApplication3 = new MakeAnApplication(
+                "",
+                "Withdraw",
+                "",
+                new ArrayList<>(),
+                "",
+                "",
+                "",
+                "");
+        makeAnApplications.add(new IdValue<>("3", makeAnApplication3));
+        when(asylumCase.read(MAKE_AN_APPLICATIONS)).thenReturn(Optional.of(makeAnApplications));
+        makeAnApplicationService = new MakeAnApplicationService();
+    }
+
+    @Test
+    public void should_return_application_when_not_decided() {
+        Optional<MakeAnApplication> makeAnApplicationOptional = makeAnApplicationService.getMakeAnApplication(asylumCase, false);
+        assertEquals("Withdraw", makeAnApplicationOptional.get().getType());
+    }
+
+    @Test
+    public void should_return_application_when_decided() {
+        when(asylumCase.read(DECIDE_AN_APPLICATION_ID)).thenReturn(Optional.of(decideAnApplicationId));
+        Optional<MakeAnApplication> makeAnApplicationOptional = makeAnApplicationService.getMakeAnApplication(asylumCase, true);
+        assertEquals("Other", makeAnApplicationOptional.get().getType());
+    }
+
+    @Test
+    public void isAppealListed() {
+        State state = State.APPEAL_SUBMITTED;
+        assertFalse(makeAnApplicationService.isApplicationListed(state));
+
+        state = State.ADJOURNED;
+        assertTrue(makeAnApplicationService.isApplicationListed(state));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = MakeAnApplicationTypes.class)
+    public void shouldMapApplicationTypeToPhrase(MakeAnApplicationTypes makeAnApplicationTypes) {
+        when(makeAnApplication.getType()).thenReturn(makeAnApplicationTypes.toString());
+
+        String expectedPhrase = makeAnApplicationService.mapApplicationTypeToPhrase(makeAnApplication);
+
+        switch (makeAnApplicationTypes) {
+            case ADJOURN:
+                assertEquals(expectedPhrase, "change the hearing date");
+                break;
+            case EXPEDITE:
+                assertEquals(expectedPhrase, "have the hearing sooner");
+                break;
+            case JUDGE_REVIEW:
+                assertEquals(expectedPhrase, "ask a judge to review the decision");
+                break;
+            case LINK_OR_UNLINK:
+                assertEquals(expectedPhrase, "link or unlink the appeal");
+                break;
+            case TIME_EXTENSION:
+                assertEquals(expectedPhrase, "ask for more time");
+                break;
+            case TRANSFER:
+                assertEquals(expectedPhrase, "move the hearing to a different location");
+                break;
+            case WITHDRAW:
+                assertEquals(expectedPhrase, "withdraw from the appeal");
+                break;
+            case UPDATE_HEARING_REQUIREMENTS:
+                assertEquals(expectedPhrase, "change some of the hearing requirements");
+                break;
+            case UPDATE_APPEAL_DETAILS:
+                assertEquals(expectedPhrase, "change some of the appeal details");
+                break;
+            case REINSTATE:
+                assertEquals(expectedPhrase, "reinstate the appeal");
+                break;
+            case OTHER:
+                assertEquals(expectedPhrase, "change something about the appeal");
+                break;
+            default:
+                break;
+        }
+    }
+}
+


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7364


### Change description ###
* Added functionality for decideAnApplication letter generation for internal cases
* Copied across makeAnApplication logic and its parsing/extraction from case data
* Added new doc tag
* Added/updated unit and FTs


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
