### PR TITLE
RIA-7365 Internal decide an application decision refused template generation

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7365-internal-ada-decide-an-application-adjourn-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7365-internal-ada-decide-an-application-adjourn-decision-refused-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7365 internal ADA application decided letter (Adjourn - Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 73651,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Adjourn",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7365-internal-ada-decide-an-application-expedite-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7365-internal-ada-decide-an-application-expedite-decision-refused-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7365 internal ADA application decided letter (Expedite - Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 73652,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Expedite",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7365-internal-ada-decide-an-application-judge-review-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7365-internal-ada-decide-an-application-judge-review-decision-refused-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7365 internal ADA application decided letter (Judges review - Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 73653,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Judge's review of Legal Officer decision",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7365-internal-ada-decide-an-application-transfer-out-of-ada-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7365-internal-ada-decide-an-application-transfer-out-of-ada-decision-refused-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7365 internal ADA application decided letter (Transfer out of ada- Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 73654,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Transfer out of accelerated detained appeals process",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7365-internal-detained-decide-an-application-adjourn-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7365-internal-detained-decide-an-application-adjourn-decision-refused-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7365 internal detained (non-ada) application decided letter (Adjourn - Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 73655,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Adjourn",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7365-internal-detained-decide-an-application-expedite-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7365-internal-detained-decide-an-application-expedite-decision-refused-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7365 internal detained (non-ada) application decided letter (Expedite - Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 73656,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Expedite",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7365-internal-detained-decide-an-application-judge-review-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7365-internal-detained-decide-an-application-judge-review-decision-refused-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7365 internal detained (non-ada) application decided letter (Judges review - Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 73657,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Judge's review of Legal Officer decision",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7365-internal-detained-decide-an-application-transfer-out-of-ada-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7365-internal-detained-decide-an-application-transfer-out-of-ada-decision-refused-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7365 internal detained (non-ada) application decided letter (Transfer out of ada - Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 73658,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Transfer out of accelerated detained appeals process",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionGrantedLetterTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionGrantedLetterTemplate.java
@@ -1,0 +1,102 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.getAppellantPersonalisation;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.util.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplicationTypes;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.DocumentTemplate;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.MakeAnApplicationService;
+
+@Component
+public class InternalDecideAnApplicationDecisionGrantedLetterTemplate implements DocumentTemplate<AsylumCase> {
+
+    private static final String timeExtentionContent = "The Tribunal will give you more time to complete your next task. You will get a notification with the new date soon.";
+    private static final String adjournExpediteTransferOrUpdateHearingReqsContent = "The details of your hearing will be updated. The Tribunal will contact you when this happens.";
+    private static final String judgesReviewContent = "The decision on your original request will be overturned. The Tribunal will contact you if there is something you need to do next.";
+    private static final String linkOrUnlinkContent = "This appeal will be linked or unlinked. The Tribunal will contact you when this happens.";
+    private static final String withdrawnContent = "The Tribunal will end the appeal. The Tribunal will contact you when this happens.";
+    private static final String updateUpdateDetailsOrOtherContent = "The Tribunal will contact you when it makes the changes you requested.";
+    private static final String transferOutOfAdaContent = "Your appeal will continue but will no longer be decided within 25 working days. The Tribunal will change the date of your hearing. The Tribunal will contact you with a new date for your hearing and to tell you what will happen next with your appeal.";
+    private final String templateName;
+    private final DateProvider dateProvider;
+    private final CustomerServicesProvider customerServicesProvider;
+    private final MakeAnApplicationService makeAnApplicationService;
+
+
+    public InternalDecideAnApplicationDecisionGrantedLetterTemplate(
+            @Value("${internalDecideAnApplicationDecisionGrantedLetter.templateName}") String templateName,
+            DateProvider dateProvider,
+            CustomerServicesProvider customerServicesProvider,
+            MakeAnApplicationService makeAnApplicationService) {
+        this.templateName = templateName;
+        this.dateProvider = dateProvider;
+        this.customerServicesProvider = customerServicesProvider;
+        this.makeAnApplicationService = makeAnApplicationService;
+    }
+
+    public String getName() {
+        return templateName;
+    }
+
+    public Map<String, Object> mapFieldValues(
+            CaseDetails<AsylumCase> caseDetails
+    ) {
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+        final Map<String, Object> fieldValues = new HashMap<>();
+
+        Optional<MakeAnApplication> optionalMakeAnApplication = getMakeAnApplication(asylumCase);
+
+        String applicationType = "";
+        String applicationDecision = "";
+        String applicationDecisionReason = "No reason given";
+        if (optionalMakeAnApplication.isPresent()) {
+            MakeAnApplication makeAnApplication = optionalMakeAnApplication.get();
+            applicationType = makeAnApplication.getType();
+            applicationDecision = makeAnApplication.getDecision();
+            applicationDecisionReason = makeAnApplication.getDecisionReason();
+        }
+
+        Optional<MakeAnApplicationTypes> optionalApplicationType = MakeAnApplicationTypes.from(applicationType);
+        MakeAnApplicationTypes makeAnApplicationTypes;
+        if (optionalApplicationType.isPresent()) {
+            makeAnApplicationTypes = optionalApplicationType.get();
+        } else {
+            throw new IllegalStateException("Application type could not be parsed");
+        }
+
+        fieldValues.putAll(getAppellantPersonalisation(asylumCase));
+        fieldValues.put("dateLetterSent", formatDateForNotificationAttachmentDocument(dateProvider.now()));
+        fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase));
+        fieldValues.put("customerServicesEmail", customerServicesProvider.getInternalCustomerServicesEmail(asylumCase));
+        fieldValues.put("applicationType", applicationType);
+        fieldValues.put("applicationReason", applicationDecisionReason);
+        fieldValues.put("whatHappensNextContent", getWhatHappensNextContent(makeAnApplicationTypes));
+
+        return fieldValues;
+    }
+
+    private Optional<MakeAnApplication> getMakeAnApplication(AsylumCase asylumCase) {
+        return makeAnApplicationService.getMakeAnApplication(asylumCase, true);
+    }
+
+    private String getWhatHappensNextContent(MakeAnApplicationTypes makeAnApplicationTypes) {
+        return switch (makeAnApplicationTypes) {
+            case TIME_EXTENSION -> timeExtentionContent;
+            case ADJOURN, EXPEDITE, TRANSFER, UPDATE_HEARING_REQUIREMENTS -> adjournExpediteTransferOrUpdateHearingReqsContent;
+            case JUDGE_REVIEW, JUDGE_REVIEW_LO -> judgesReviewContent;
+            case LINK_OR_UNLINK -> linkOrUnlinkContent;
+            case WITHDRAW -> withdrawnContent;
+            case UPDATE_APPEAL_DETAILS, OTHER -> updateUpdateDetailsOrOtherContent;
+            case TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS -> transferOutOfAdaContent;
+            default -> "Unknown";
+        };
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
@@ -961,13 +961,34 @@ public class DocumentCreatorConfiguration {
         );
     }
 
-    @Bean("internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter")
+    @Bean("internalDecideAnApplicationDecisionGrantedLetter")
     public DocumentCreator<AsylumCase> getinternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterCreator(
-            @Value("${internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.contentType}") String contentType,
-            @Value("${internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.fileExtension}") String fileExtension,
-            @Value("${internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.fileName}") String fileName,
+            @Value("${internalDecideAnApplicationDecisionGrantedLetter.contentType}") String contentType,
+            @Value("${internalDecideAnApplicationDecisionGrantedLetter.fileExtension}") String fileExtension,
+            @Value("${internalDecideAnApplicationDecisionGrantedLetter.fileName}") String fileName,
             AsylumCaseFileNameQualifier fileNameQualifier,
-            InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate documentTemplate,
+            InternalDecideAnApplicationDecisionGrantedLetterTemplate documentTemplate,
+            DocumentGenerator documentGenerator,
+            DocumentUploader documentUploader
+    ) {
+        return new DocumentCreator<>(
+                contentType,
+                fileExtension,
+                fileName,
+                fileNameQualifier,
+                documentTemplate,
+                documentGenerator,
+                documentUploader
+        );
+    }
+
+    @Bean("internalDecideAnApplicationDecisionRefusedLetter")
+    public DocumentCreator<AsylumCase> getinternalDetainedDecideAnApplicationDecisionRefusedLetterCreator(
+            @Value("${internalDecideAnApplicationDecisionRefusedLetter.contentType}") String contentType,
+            @Value("${internalDecideAnApplicationDecisionRefusedLetter.fileExtension}") String fileExtension,
+            @Value("${internalDecideAnApplicationDecisionRefusedLetter.fileName}") String fileName,
+            AsylumCaseFileNameQualifier fileNameQualifier,
+            InternalDecideAnApplicationDecisionRefusedLetterTemplate documentTemplate,
             DocumentGenerator documentGenerator,
             DocumentUploader documentUploader
     ) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -299,10 +299,15 @@ internalMarkAppealAsAda.fileExtension: PDF
 internalMarkAppealAsAda.fileName: "detained-appellant-mark-as-ada-notice"
 internalMarkAppealAsAda.templateName: ${IA_INTERNAL_MARK_APPEAL_AS_ADA_TEMPLATE:TB-IAC-LET-ENG-00008.docx}
 
-internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.contentType: application/pdf
-internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.fileExtension: PDF
-internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.fileName: "appellant-letter-application-granted"
-internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetter.templateName: ${IA_INTERNAL_DETAINED_AND_ADA_DECIDE_AN_APPLICATION_DECISION_GRANTED_LETTER_TEMPLATE:TB-IAC-LET-ENG-00015.docx}
+internalDecideAnApplicationDecisionGrantedLetter.contentType: application/pdf
+internalDecideAnApplicationDecisionGrantedLetter.fileExtension: PDF
+internalDecideAnApplicationDecisionGrantedLetter.fileName: "appellant-letter-application-granted"
+internalDecideAnApplicationDecisionGrantedLetter.templateName: ${IA_INTERNAL_DECIDE_AN_APPLICATION_DECISION_GRANTED_LETTER_TEMPLATE:TB-IAC-LET-ENG-00015.docx}
+
+internalDecideAnApplicationDecisionRefusedLetter.contentType: application/pdf
+internalDecideAnApplicationDecisionRefusedLetter.fileExtension: PDF
+internalDecideAnApplicationDecisionRefusedLetter.fileName: "appellant-letter-application-refused"
+internalDecideAnApplicationDecisionRefusedLetter.templateName: ${IA_INTERNAL_DECIDE_AN_APPLICATION_DECISION_REFUSED_LETTER_TEMPLATE:TB-IAC-LET-ENG-00016.docx}
 
 ccdGatewayUrl: ${CCD_GW_URL:http://localhost:3453}
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionGrantedLetterTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionGrantedLetterTemplateTest.java
@@ -30,7 +30,7 @@ import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.MakeAnApplicationSe
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplateTest {
+public class InternalDecideAnApplicationDecisionGrantedLetterTemplateTest {
     @Mock
     private CaseDetails<AsylumCase> caseDetails;
     @Mock
@@ -51,18 +51,16 @@ public class InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTempl
     private final String transferOutOfAdaContent = "Your appeal will continue but will no longer be decided within 25 working days. The Tribunal will change the date of your hearing. The Tribunal will contact you with a new date for your hearing and to tell you what will happen next with your appeal.";
     private final String internalAdaCustomerServicesTelephoneNumber = "0300 123 1711";
     private final String internalAdaCustomerServicesEmailAddress = "IAC-ADA-HW@justice.gov.uk";
-    private final String internalDetainedCustomerServicesTelephoneNumber = "0300 123 1711";
-    private final String internalDetainedCustomerServicesEmailAddress = "contactia@justice.gov.uk";
     private final String appealReferenceNumber = "RP/11111/2020";
     private final String homeOfficeReferenceNumber = "A1234567/001";
     private final String appellantGivenNames = "John";
     private final String appellantFamilyName = "Doe";
-    private InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate;
+    private InternalDecideAnApplicationDecisionGrantedLetterTemplate internalDecideAnApplicationDecisionGrantedLetterTemplate;
 
     @BeforeEach
     void setUp() {
-        internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate =
-                new InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate(
+        internalDecideAnApplicationDecisionGrantedLetterTemplate =
+                new InternalDecideAnApplicationDecisionGrantedLetterTemplate(
                         templateName,
                         dateProvider,
                         customerServicesProvider,
@@ -88,7 +86,7 @@ public class InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTempl
 
     @Test
     void should_return_template_name() {
-        assertEquals(templateName, internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate.getName());
+        assertEquals(templateName, internalDecideAnApplicationDecisionGrantedLetterTemplate.getName());
     }
 
     @ParameterizedTest
@@ -112,7 +110,7 @@ public class InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTempl
 
         when(makeAnApplicationService.getMakeAnApplication(asylumCase, true)).thenReturn(Optional.of(testApplication));
 
-        Map<String, Object> templateFieldValues = internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate.mapFieldValues(caseDetails);
+        Map<String, Object> templateFieldValues = internalDecideAnApplicationDecisionGrantedLetterTemplate.mapFieldValues(caseDetails);
 
         assertEquals(11, templateFieldValues.size());
         assertEquals("[userImage:hmcts.png]", templateFieldValues.get("hmcts"));
@@ -158,7 +156,7 @@ public class InternalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTempl
 
         when(makeAnApplicationService.getMakeAnApplication(asylumCase, true)).thenReturn(Optional.of(testApplication));
 
-        assertThatThrownBy(() -> internalDetainedAndAdaDecideAnApplicationDecisionGrantedLetterTemplate.mapFieldValues(caseDetails))
+        assertThatThrownBy(() -> internalDecideAnApplicationDecisionGrantedLetterTemplate.mapFieldValues(caseDetails))
                 .hasMessage("Application type could not be parsed")
                 .isExactlyInstanceOf(IllegalStateException.class);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionRefusedLetterTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionRefusedLetterTemplateTest.java
@@ -1,0 +1,199 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.time.LocalDate;
+import java.util.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.DateProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.UserDetailsProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.MakeAnApplication;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.UserDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.State;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.MakeAnApplicationService;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class InternalDecideAnApplicationDecisionRefusedLetterTemplateTest {
+
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private DateProvider dateProvider;
+    @Mock
+    private CustomerServicesProvider customerServicesProvider;
+    @Mock
+    private MakeAnApplicationService makeAnApplicationService;
+    @Mock
+    UserDetailsProvider userDetailsProvider;
+    @Mock
+    UserDetails userDetails;
+    private final String judgeRole = "caseworker-ia-iacjudge";
+    private final String legalOfficerRole = "caseworker-ia-caseofficer";
+    private final String applicationRefusedAdaFormName = "IAFT-ADA4: Make an application – Accelerated detained appeal (ADA)";
+    private final String applicationRefusedDetainedNonAdaFormName = "IAFT-DE4: Make an application – Detained appeal";
+    private final String templateName = "TB-IAC-DEC-ENG-00016.docx";
+    private final String internalAdaCustomerServicesTelephoneNumber = "0300 123 1711";
+    private final String internalAdaCustomerServicesEmailAddress = "IAC-ADA-HW@justice.gov.uk";
+    private final String appealReferenceNumber = "RP/11111/2020";
+    private final String homeOfficeReferenceNumber = "A1234567/001";
+    private final String appellantGivenNames = "John";
+    private final String appellantFamilyName = "Doe";
+    private List<IdValue<MakeAnApplication>> makeAnApplications = new ArrayList<>();
+    private final MakeAnApplication application = new MakeAnApplication(
+            "Admin Officer",
+            "Adjourn",
+            "someRandomDetails",
+            new ArrayList<>(),
+            LocalDate.now().toString(),
+            "Refused",
+            State.APPEAL_SUBMITTED.toString(),
+            "caseworker-ia-admofficer");
+    private InternalDecideAnApplicationDecisionRefusedLetterTemplate internalDecideAnApplicationDecisionRefusedLetterTemplate;
+
+    @BeforeEach
+    void setUp() {
+        internalDecideAnApplicationDecisionRefusedLetterTemplate =
+                new InternalDecideAnApplicationDecisionRefusedLetterTemplate(
+                        templateName,
+                        dateProvider,
+                        customerServicesProvider,
+                        makeAnApplicationService,
+                        userDetailsProvider
+                );
+    }
+
+    void dataSetup() {
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+
+        when(customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase))
+                .thenReturn(internalAdaCustomerServicesTelephoneNumber);
+        when(customerServicesProvider.getInternalCustomerServicesEmail(asylumCase))
+                .thenReturn(internalAdaCustomerServicesEmailAddress);
+
+        when(dateProvider.now()).thenReturn(LocalDate.now());
+
+        when(userDetailsProvider.getUserDetails()).thenReturn(userDetails);
+        when(userDetails.getRoles()).thenReturn(List.of(judgeRole));
+
+        makeAnApplications.add(new IdValue<>("1", application));
+
+        when(asylumCase.read(MAKE_AN_APPLICATIONS)).thenReturn(Optional.of(makeAnApplications));
+        when(asylumCase.read(DECIDE_AN_APPLICATION_ID)).thenReturn(Optional.of("1"));
+
+        when(makeAnApplicationService.getMakeAnApplication(asylumCase, true)).thenReturn(Optional.of(application));
+    }
+
+    @Test
+    void should_return_template_name() {
+        assertEquals(templateName, internalDecideAnApplicationDecisionRefusedLetterTemplate.getName());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {judgeRole, legalOfficerRole})
+    void should_map_case_data_to_template_field_values_and_map_decision_maker_field_correctly(String role) {
+        dataSetup();
+
+        when(userDetailsProvider.getUserDetails().getRoles()).thenReturn(List.of(role));
+
+        Map<String, Object> templateFieldValues = internalDecideAnApplicationDecisionRefusedLetterTemplate.mapFieldValues(caseDetails);
+
+        assertEquals(12, templateFieldValues.size());
+        assertEquals("[userImage:hmcts.png]", templateFieldValues.get("hmcts"));
+        assertEquals(appealReferenceNumber, templateFieldValues.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, templateFieldValues.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, templateFieldValues.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, templateFieldValues.get("appellantFamilyName"));
+        assertEquals(internalAdaCustomerServicesTelephoneNumber, templateFieldValues.get("customerServicesTelephone"));
+        assertEquals(internalAdaCustomerServicesEmailAddress, templateFieldValues.get("customerServicesEmail"));
+        assertEquals(formatDateForNotificationAttachmentDocument(dateProvider.now()), templateFieldValues.get("dateLetterSent"));
+        assertEquals(application.getType(), templateFieldValues.get("applicationType"));
+        assertEquals(application.getDecisionReason(), templateFieldValues.get("applicationReason"));
+        assertEquals(applicationRefusedDetainedNonAdaFormName, templateFieldValues.get("formName"));
+
+        if (role.equals(judgeRole)) {
+            assertEquals("Judge", templateFieldValues.get("decisionMaker"));
+        } else if (role.equals(legalOfficerRole)) {
+            assertEquals("Legal Officer", templateFieldValues.get("decisionMaker"));
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = YesOrNo.class)
+    void should_map_case_data_to_template_field_values_and_map_decision_maker_field_correctly(YesOrNo yesOrNo) {
+        dataSetup();
+        when(asylumCase.read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(yesOrNo));
+        Map<String, Object> templateFieldValues = internalDecideAnApplicationDecisionRefusedLetterTemplate.mapFieldValues(caseDetails);
+
+        assertEquals(12, templateFieldValues.size());
+        assertEquals("[userImage:hmcts.png]", templateFieldValues.get("hmcts"));
+        assertEquals(appealReferenceNumber, templateFieldValues.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, templateFieldValues.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, templateFieldValues.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, templateFieldValues.get("appellantFamilyName"));
+        assertEquals(internalAdaCustomerServicesTelephoneNumber, templateFieldValues.get("customerServicesTelephone"));
+        assertEquals(internalAdaCustomerServicesEmailAddress, templateFieldValues.get("customerServicesEmail"));
+        assertEquals(formatDateForNotificationAttachmentDocument(dateProvider.now()), templateFieldValues.get("dateLetterSent"));
+        assertEquals(application.getType(), templateFieldValues.get("applicationType"));
+        assertEquals(application.getDecisionReason(), templateFieldValues.get("applicationReason"));
+        assertEquals("Judge", templateFieldValues.get("decisionMaker"));
+
+
+        if (yesOrNo.equals(YesOrNo.YES)) {
+            assertEquals(applicationRefusedAdaFormName, templateFieldValues.get("formName"));
+        } else {
+            assertEquals(applicationRefusedDetainedNonAdaFormName, templateFieldValues.get("formName"));
+        }
+    }
+
+    @Test
+    void should_throw_exception_if_application_type_cannot_be_parsed() {
+        dataSetup();
+        List<IdValue<MakeAnApplication>> makeAnApplications = new ArrayList<>();
+        final MakeAnApplication testApplication = new MakeAnApplication(
+                "Admin Officer",
+                "someRandomApplicationTypeThatShouldCauseAnException",
+                "someRandomDetails",
+                new ArrayList<>(),
+                LocalDate.now().toString(),
+                "Granted",
+                State.APPEAL_SUBMITTED.toString(),
+                "caseworker-ia-admofficer");
+        makeAnApplications.add(new IdValue<>("1", testApplication));
+
+        when(asylumCase.read(MAKE_AN_APPLICATIONS)).thenReturn(Optional.of(makeAnApplications));
+        when(asylumCase.read(DECIDE_AN_APPLICATION_ID)).thenReturn(Optional.of("1"));
+
+        when(makeAnApplicationService.getMakeAnApplication(asylumCase, true)).thenReturn(Optional.of(testApplication));
+
+        assertThatThrownBy(() -> internalDecideAnApplicationDecisionRefusedLetterTemplate.mapFieldValues(caseDetails))
+                .hasMessage("Application type could not be parsed")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7365


### Change description ###
* Added new template for internal decide an application where decision is refused
* Refactored 7364 so granted+refused use a single handler with independent DocumentCreatorConfiguration beans and seperate templates.
* Added/updated unit/FTs.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
