### PR TITLE
RIA-TASK Use fallback if CDAM doesn't work yet

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,7 +20,7 @@
         ]]</notes>
         <cve>CVE-2022-45688</cve>
     </suppress>
-    <suppress until="2023-09-31">
+    <suppress until="2023-09-30">
         <cve>CVE-2023-35116</cve><!-- 2023-08-03 jackson-databind 2.15.2 (the latest version at time of checking) is still vulnerable. Try again when a new version comes out. -->
     </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,7 +20,7 @@
         ]]</notes>
         <cve>CVE-2022-45688</cve>
     </suppress>
-    <suppress until="2023-08-31">
+    <suppress until="2023-09-31">
         <cve>CVE-2023-35116</cve><!-- 2023-08-03 jackson-databind 2.15.2 (the latest version at time of checking) is still vulnerable. Try again when a new version comes out. -->
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/clients/DocumentDownloadClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/clients/DocumentDownloadClient.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.clients;
 
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.FeatureToggler;
@@ -8,6 +10,7 @@ import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.FeatureToggler;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class DocumentDownloadClient {
 
 
@@ -19,10 +22,53 @@ public class DocumentDownloadClient {
 
     public Resource download(String documentBinaryUrl) {
         if (featureToggler.getValue("use-ccd-document-am", false)) {
-            return cdamDocumentDownLoadClient.download(documentBinaryUrl);
+            // the below to be uncommented once downloadWithFallback will no longer be needed.
+            //return cdamDocumentDownLoadClient.download(documentBinaryUrl);
+            return downloadWithFallback(documentBinaryUrl);
         } else {
             return dmDocumentDownloadClient.download(documentBinaryUrl);
         }
     }
 
+    /**
+     * <p>
+     *     Added on: 2023-08-30<br/>
+     *     Incident: INC5541389<br/>
+     *     Related ticket: RPMO-3511
+     * </p>
+     * <p>
+     *     This is a fallback method to allow using the unsecured document store (dm) as opposed to the secured one
+     *     (cdam) in case the secured one throws an HTTP-403.
+     *     This method is not meant to be a permanent feature and it's meant to allow us to keep our feature flag
+     *     turned on while ExUI waits for some work to be completed as well on their side.
+     * </p>
+     * <p>
+     *     Once their work is completed, proceed as follows:
+     *     1. add the use-ccd-document-am-fallback to production and switch it OFF
+     *     2. give it a few weeks to ensure that all documents can be uploaded and downloaded without issues,
+     *        monitoring the logs
+     *     3. delete this method
+     * </p>
+     *
+     * @param documentBinaryUrl
+     * @return
+     */
+    private Resource downloadWithFallback(String documentBinaryUrl) {
+        try {
+            return cdamDocumentDownLoadClient.download(documentBinaryUrl);
+        } catch (FeignException ex) {
+            if (ex.status() == 403) {
+                if (!featureToggler.getValue("use-ccd-document-am-fallback", true)) {
+                    throw ex;
+                }
+                log.warn("A download using CDAM failed with an HTTP-403. This may be happening due to CDAM changes " +
+                    "not being switched ON just yet in ExUI. A fallback will be used. Once confirmation is received " +
+                    "that CDAM changes have been turned on in ExUI, create and switch OFF the " +
+                    "use-ccd-document-am-fallback flag. Ticket reference: RPMO-3511.");
+                return dmDocumentDownloadClient.download(documentBinaryUrl);
+            } else {
+                throw ex;
+            }
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/clients/DocumentDownloadClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/clients/DocumentDownloadClient.java
@@ -34,7 +34,7 @@ public class DocumentDownloadClient {
      * <p>
      *     Added on: 2023-08-30<br/>
      *     Incident: INC5541389<br/>
-     *     Related ticket: RPMO-3511
+     *     Related ticket: RPMO-3511.
      * </p>
      * <p>
      *     This is a fallback method to allow using the unsecured document store (dm) as opposed to the secured one
@@ -50,8 +50,8 @@ public class DocumentDownloadClient {
      *     3. delete this method
      * </p>
      *
-     * @param documentBinaryUrl
-     * @return
+     * @param documentBinaryUrl The url
+     * @return A resource
      */
     private Resource downloadWithFallback(String documentBinaryUrl) {
         try {

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/DocumentDownloadClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/DocumentDownloadClientTest.java
@@ -1,10 +1,6 @@
 package uk.gov.hmcts.reform.iacasedocumentsapi.domain.service;
 
-import java.io.IOException;
-import java.util.HashMap;
-
 import feign.FeignException;
-import feign.Request;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,8 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings("unchecked")
-public class DocumentDownloadClientTest {
+class DocumentDownloadClientTest {
     @Mock
     private FeatureToggler featureToggler;
     @Mock
@@ -45,7 +40,7 @@ public class DocumentDownloadClientTest {
     }
 
     @Test
-    void should_use_cdam_when_feature_flag_true() throws IOException {
+    void should_use_cdam_when_feature_flag_true() {
         // Given
         given(featureToggler.getValue(eq("use-ccd-document-am"), anyBoolean())).willReturn(true);
 
@@ -57,7 +52,7 @@ public class DocumentDownloadClientTest {
     }
 
     @Test
-    void should_use_dm_when_feature_flag_false() throws IOException {
+    void should_use_dm_when_feature_flag_false() {
         // Given
         given(featureToggler.getValue(eq("use-ccd-document-am"), anyBoolean())).willReturn(false);
 
@@ -69,7 +64,7 @@ public class DocumentDownloadClientTest {
     }
 
     @Test
-    void should_use_fallback_when_cdam_fails() throws IOException {
+    void should_use_fallback_when_cdam_fails() {
         // Given
         given(featureToggler.getValue(eq("use-ccd-document-am"), anyBoolean())).willReturn(true);
         given(featureToggler.getValue(eq("use-ccd-document-am-fallback"), anyBoolean())).willReturn(true);
@@ -88,7 +83,7 @@ public class DocumentDownloadClientTest {
     }
 
     @Test
-    void should_not_use_fallback_when_cdam_fails() throws IOException {
+    void should_not_use_fallback_when_cdam_fails() {
         // Given
         given(featureToggler.getValue(eq("use-ccd-document-am"), anyBoolean())).willReturn(true);
         given(featureToggler.getValue(eq("use-ccd-document-am-fallback"), anyBoolean())).willReturn(false);


### PR DESCRIPTION
### JIRA link (if applicable) ###
RIA-5804


### Change description ###
Uses a fallback to the unsecured dm-store if the secured one (cdam) returns a 403, assuming that the issue is the ExUI feature flag is still turned off.

Provides appropriate descriptions in the logs and in the code with guidance on how to deal with the issue when the time comes.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
