### PR TITLE
RIA-7844 reinstate content added to InternalDecideAnApplicationDecisionGrantedLetterTemplate

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7844-internal-ada-decide-an-application-reinstate-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7844-internal-ada-decide-an-application-reinstate-decision-granted-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7844 internal ADA application decided letter (Reinstate - Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 7844,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Reinstate an ended appeal",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7844-internal-ada-decide-an-application-reinstate-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7844-internal-ada-decide-an-application-reinstate-decision-refused-letter.json
@@ -1,0 +1,63 @@
+{
+  "description": "RIA-7844 internal ADA application decided letter (Reinstate - Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 7844,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Reinstate an ended appeal",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7844-internal-detained-decide-an-application-reinstate-decision-granted-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7844-internal-detained-decide-an-application-reinstate-decision-granted-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7844 internal detained (non-ada) application decided letter (Reinstate - Granted)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "id": 7844,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Reinstate an ended appeal",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Granted",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-granted.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7844-internal-detained-decide-an-application-reinstate-decision-refused-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7844-internal-detained-decide-an-application-reinstate-decision-refused-letter.json
@@ -1,0 +1,62 @@
+{
+  "description": "RIA-7844 internal detained (non-ada) application decided letter (Reinstate - Refused)",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "Judge",
+    "input": {
+      "id": 7844,
+      "eventId": "decideAnApplication",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "decideAnApplicationId": "1",
+          "makeAnApplications": [
+            {
+              "id": "1",
+              "value": {
+                "type":"Reinstate an ended appeal",
+                "details":"",
+                "evidence":[],
+                "applicant":"",
+                "date":"{$TODAY}",
+                "decision":"Refused",
+                "state":"appealSubmitted",
+                "applicantRole":"caseworker-ia-admofficer",
+                "decisionReason":"No Reason given",
+                "decisionDate":"{$TODAY}",
+                "decisionMaker": "Admin Officer"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant-letter-application-refused.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalDecideAnApplicationLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionGrantedLetterTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionGrantedLetterTemplate.java
@@ -25,6 +25,7 @@ public class InternalDecideAnApplicationDecisionGrantedLetterTemplate implements
     private static final String withdrawnContent = "The Tribunal will end the appeal. The Tribunal will contact you when this happens.";
     private static final String updateUpdateDetailsOrOtherContent = "The Tribunal will contact you when it makes the changes you requested.";
     private static final String transferOutOfAdaContent = "Your appeal will continue but will no longer be decided within 25 working days. The Tribunal will change the date of your hearing. The Tribunal will contact you with a new date for your hearing and to tell you what will happen next with your appeal.";
+    private static final String reinstateAppealContent = "This appeal will be reinstated and will continue from the point where it was ended. You will be notified when this happens";
     private final String templateName;
     private final DateProvider dateProvider;
     private final CustomerServicesProvider customerServicesProvider;
@@ -94,6 +95,7 @@ public class InternalDecideAnApplicationDecisionGrantedLetterTemplate implements
             case JUDGE_REVIEW, JUDGE_REVIEW_LO -> judgesReviewContent;
             case LINK_OR_UNLINK -> linkOrUnlinkContent;
             case WITHDRAW -> withdrawnContent;
+            case REINSTATE -> reinstateAppealContent;
             case UPDATE_APPEAL_DETAILS, OTHER -> updateUpdateDetailsOrOtherContent;
             case TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS -> transferOutOfAdaContent;
             default -> "Unknown";

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionGrantedLetterTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalDecideAnApplicationDecisionGrantedLetterTemplateTest.java
@@ -49,6 +49,8 @@ public class InternalDecideAnApplicationDecisionGrantedLetterTemplateTest {
     private final String withdrawnContent = "The Tribunal will end the appeal. The Tribunal will contact you when this happens.";
     private final String updateUpdateDetailsOrOtherContent = "The Tribunal will contact you when it makes the changes you requested.";
     private final String transferOutOfAdaContent = "Your appeal will continue but will no longer be decided within 25 working days. The Tribunal will change the date of your hearing. The Tribunal will contact you with a new date for your hearing and to tell you what will happen next with your appeal.";
+    private static final String reinstateAppealContent = "This appeal will be reinstated and will continue from the point where it was ended. You will be notified when this happens";
+
     private final String internalAdaCustomerServicesTelephoneNumber = "0300 123 1711";
     private final String internalAdaCustomerServicesEmailAddress = "IAC-ADA-HW@justice.gov.uk";
     private final String appealReferenceNumber = "RP/11111/2020";
@@ -130,6 +132,7 @@ public class InternalDecideAnApplicationDecisionGrantedLetterTemplateTest {
             case JUDGE_REVIEW, JUDGE_REVIEW_LO -> assertEquals(judgesReviewContent, templateFieldValues.get("whatHappensNextContent"));
             case LINK_OR_UNLINK -> assertEquals(linkOrUnlinkContent, templateFieldValues.get("whatHappensNextContent"));
             case WITHDRAW -> assertEquals(withdrawnContent, templateFieldValues.get("whatHappensNextContent"));
+            case REINSTATE -> assertEquals(reinstateAppealContent, templateFieldValues.get("whatHappensNextContent"));
             case UPDATE_APPEAL_DETAILS, OTHER -> assertEquals(updateUpdateDetailsOrOtherContent, templateFieldValues.get("whatHappensNextContent"));
             case TRANSFER_OUT_OF_ACCELERATED_DETAINED_APPEALS_PROCESS -> assertEquals(transferOutOfAdaContent, templateFieldValues.get("whatHappensNextContent"));
             default -> { }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7844


### Change description ###
* Added content for application type - reinstate to InternalDecideAnApplicationDecisionGrantedLetterTemplate.getWhatHappensNextContent()
* Added reinstate content test
* Added FTs for reinstate application type when decided


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
