### PR TITLE
RIA-7322 hearingDate removed from template

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7322-internal-hearing-requirements-updated-ada-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7322-internal-hearing-requirements-updated-ada-letter.json
@@ -11,8 +11,7 @@
         "template": "minimal-internal-appeal-submitted.json",
         "replacements": {
           "appellantInDetention": "Yes",
-          "isAcceleratedDetainedAppeal": "Yes",
-          "listCaseHearingDate": "2023-09-25T14:30:00"
+          "isAcceleratedDetainedAppeal": "Yes"
         }
       }
     }
@@ -25,7 +24,6 @@
       "replacements": {
         "appellantInDetention": "Yes",
         "isAcceleratedDetainedAppeal": "Yes",
-        "listCaseHearingDate": "2023-09-25T14:30:00",
         "notificationAttachmentDocuments": [
           {
             "id": "1",

--- a/src/functionalTest/resources/scenarios/RIA-7322-internal-hearing-requirements-updated-non-ada-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-7322-internal-hearing-requirements-updated-non-ada-letter.json
@@ -11,8 +11,7 @@
         "template": "minimal-internal-appeal-submitted.json",
         "replacements": {
           "appellantInDetention": "Yes",
-          "isAcceleratedDetainedAppeal": "No",
-          "listCaseHearingDate": "2023-09-25T14:30:00"
+          "isAcceleratedDetainedAppeal": "No"
         }
       }
     }
@@ -25,7 +24,6 @@
       "replacements": {
         "appellantInDetention": "Yes",
         "isAcceleratedDetainedAppeal": "No",
-        "listCaseHearingDate": "2023-09-25T14:30:00",
         "notificationAttachmentDocuments": [
           {
             "id": "1",

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalHearingRequirementsUpdatedLetterTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalHearingRequirementsUpdatedLetterTemplate.java
@@ -1,11 +1,8 @@
 package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
 
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.LIST_CASE_HEARING_DATE;
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.formatDateTimeForRendering;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.getAppellantPersonalisation;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
 
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +19,6 @@ public class InternalHearingRequirementsUpdatedLetterTemplate implements Documen
     private final String templateName;
     private final DateProvider dateProvider;
     private final CustomerServicesProvider customerServicesProvider;
-    private static final DateTimeFormatter DOCUMENT_DATE_FORMAT = DateTimeFormatter.ofPattern("d MMMM yyyy");
 
     public InternalHearingRequirementsUpdatedLetterTemplate(
         @Value("${internalHearingRequirementsUpdated.templateName}") String templateName,
@@ -48,7 +44,6 @@ public class InternalHearingRequirementsUpdatedLetterTemplate implements Documen
         fieldValues.put("dateLetterSent", formatDateForNotificationAttachmentDocument(dateProvider.now()));
         fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase));
         fieldValues.put("customerServicesEmail", customerServicesProvider.getInternalCustomerServicesEmail(asylumCase));
-        fieldValues.put("hearingDate", formatDateTimeForRendering(asylumCase.read(LIST_CASE_HEARING_DATE, String.class).orElse(""), DOCUMENT_DATE_FORMAT));
 
         return fieldValues;
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalHearingRequirementsUpdatedLetterTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalHearingRequirementsUpdatedLetterTemplateTest.java
@@ -35,8 +35,6 @@ public class InternalHearingRequirementsUpdatedLetterTemplateTest {
     private final String homeOfficeReferenceNumber = "A1234567/001";
     private final String appellantGivenNames = "John";
     private final String appellantFamilyName = "Doe";
-    private final String listCaseHearingDate = "2023-09-25T14:30:00.000";
-    private final String formattedListCaseHearingDate = "25 September 2023";
     private final String customerServicesTelephone = "0300 123 1711";
     private final String customerServicesEmail = "email@example.com";
 
@@ -63,7 +61,6 @@ public class InternalHearingRequirementsUpdatedLetterTemplateTest {
         when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
         when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
         when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
-        when(asylumCase.read(LIST_CASE_HEARING_DATE, String.class)).thenReturn(Optional.of(listCaseHearingDate));
         when(customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase)).thenReturn(customerServicesTelephone);
         when(customerServicesProvider.getInternalCustomerServicesEmail(asylumCase)).thenReturn(customerServicesEmail);
         when(dateProvider.now()).thenReturn(LocalDate.now());
@@ -75,13 +72,12 @@ public class InternalHearingRequirementsUpdatedLetterTemplateTest {
 
         Map<String, Object> templateFieldValues = internalHearingRequirementsUpdatedLetterTemplate.mapFieldValues(caseDetails);
 
-        assertEquals(9, templateFieldValues.size());
+        assertEquals(8, templateFieldValues.size());
         assertEquals(appealReferenceNumber, templateFieldValues.get("appealReferenceNumber"));
         assertEquals(homeOfficeReferenceNumber, templateFieldValues.get("homeOfficeReferenceNumber"));
         assertEquals(appellantGivenNames, templateFieldValues.get("appellantGivenNames"));
         assertEquals(appellantFamilyName, templateFieldValues.get("appellantFamilyName"));
         assertEquals(formatDateForNotificationAttachmentDocument(dateProvider.now()), templateFieldValues.get("dateLetterSent"));
-        assertEquals(formattedListCaseHearingDate, templateFieldValues.get("hearingDate"));
         assertEquals(customerServicesTelephone, templateFieldValues.get("customerServicesTelephone"));
         assertEquals(customerServicesEmail, templateFieldValues.get("customerServicesEmail"));
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-7322

### Change description ###

- hearingDate no longer a field in template. Removed these values from personalisation, unit tests and functional tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
