### PR TITLE
RIA-7370 HO upload additional/addendum evidence + LO upload addendum evidence doc generation

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-7370-internal-ada-home-office-upload-addendum-evidence.json
+++ b/src/functionalTest/resources/scenarios/RIA-7370-internal-ada-home-office-upload-addendum-evidence.json
@@ -1,0 +1,76 @@
+{
+  "description": "RIA-7370 - Internal upload home office upload addendum evidence letter generation - ADA",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "HomeOfficeLart",
+    "input": {
+      "eventId": "uploadAddendumEvidenceHomeOffice",
+      "state": "decided",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "addendumEvidenceDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "addendumEvidence",
+                "document": {
+                  "document_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79",
+                  "document_filename": "fake-doc.pdf",
+                  "document_binary_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79/binary"
+                },
+                "suppliedBy": "The respondent",
+                "description": "HO addendum 1",
+                "dateUploaded": "2023-09-26"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "addendumEvidenceDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "addendumEvidence",
+              "document": {
+                "document_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79",
+                "document_filename": "fake-doc.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79/binary"
+              },
+              "suppliedBy": "The respondent",
+              "description": "HO addendum 1",
+              "dateUploaded": "2023-09-26"
+            }
+          }
+        ],
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant letter_HO-evidence.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "homeOfficeUploadAdditionalAddendumEvidenceLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7370-internal-ada-home-office-upload-additional-evidence.json
+++ b/src/functionalTest/resources/scenarios/RIA-7370-internal-ada-home-office-upload-additional-evidence.json
@@ -1,0 +1,76 @@
+{
+  "description": "RIA-7370 - Internal upload home office upload additional evidence letter generation - ADA",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "HomeOfficeLart",
+    "input": {
+      "eventId": "uploadAdditionalEvidenceHomeOffice",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "addendumEvidenceDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "addendumEvidence",
+                "document": {
+                  "document_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79",
+                  "document_filename": "fake-doc.pdf",
+                  "document_binary_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79/binary"
+                },
+                "suppliedBy": "The respondent",
+                "description": "HO addendum 1",
+                "dateUploaded": "2023-09-26"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "addendumEvidenceDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "addendumEvidence",
+              "document": {
+                "document_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79",
+                "document_filename": "fake-doc.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79/binary"
+              },
+              "suppliedBy": "The respondent",
+              "description": "HO addendum 1",
+              "dateUploaded": "2023-09-26"
+            }
+          }
+        ],
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant letter_HO-evidence.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "homeOfficeUploadAdditionalAddendumEvidenceLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7370-internal-ada-legal-officer-upload-addendum-evidence-supplied-by-ho.json
+++ b/src/functionalTest/resources/scenarios/RIA-7370-internal-ada-legal-officer-upload-addendum-evidence-supplied-by-ho.json
@@ -1,0 +1,78 @@
+{
+  "description": "RIA-7370 - Internal upload Legal Officer upload addendum evidence letter generation - ADA",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "uploadAddendumEvidence",
+      "state": "decided",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "Yes",
+          "addendumEvidenceDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "addendumEvidence",
+                "document": {
+                  "document_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313",
+                  "document_filename": "fake-doc.pdf",
+                  "document_binary_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313/binary"
+                },
+                "suppliedBy": "The respondent",
+                "uploadedBy": "TCW",
+                "description": "k",
+                "dateUploaded": "2023-09-26"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "isAcceleratedDetainedAppeal": "Yes",
+        "addendumEvidenceDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "addendumEvidence",
+              "document": {
+                "document_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313",
+                "document_filename": "fake-doc.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313/binary"
+              },
+              "suppliedBy": "The respondent",
+              "uploadedBy": "TCW",
+              "description": "k",
+              "dateUploaded": "2023-09-26"
+            }
+          }
+        ],
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant letter_LO-evidence.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "legalOfficerUploadAdditionalEvidenceLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7370-internal-detained-home-office-upload-addendum-evidence.json
+++ b/src/functionalTest/resources/scenarios/RIA-7370-internal-detained-home-office-upload-addendum-evidence.json
@@ -1,0 +1,76 @@
+{
+  "description": "RIA-7370 - Internal upload home office upload addendum evidence letter generation - Detained non-ada",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "HomeOfficeLart",
+    "input": {
+      "eventId": "uploadAddendumEvidenceHomeOffice",
+      "state": "decided",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "No",
+          "addendumEvidenceDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "addendumEvidence",
+                "document": {
+                  "document_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79",
+                  "document_filename": "fake-doc.pdf",
+                  "document_binary_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79/binary"
+                },
+                "suppliedBy": "The respondent",
+                "description": "HO addendum 1",
+                "dateUploaded": "2023-09-26"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "isAcceleratedDetainedAppeal": "No",
+        "addendumEvidenceDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "addendumEvidence",
+              "document": {
+                "document_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79",
+                "document_filename": "fake-doc.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79/binary"
+              },
+              "suppliedBy": "The respondent",
+              "description": "HO addendum 1",
+              "dateUploaded": "2023-09-26"
+            }
+          }
+        ],
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant letter_HO-evidence.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "homeOfficeUploadAdditionalAddendumEvidenceLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7370-internal-detained-home-office-upload-additional-evidence.json
+++ b/src/functionalTest/resources/scenarios/RIA-7370-internal-detained-home-office-upload-additional-evidence.json
@@ -1,0 +1,76 @@
+{
+  "description": "RIA-7370 - Internal upload home office upload additional evidence letter generation - Detained non-ada",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "HomeOfficeLart",
+    "input": {
+      "eventId": "uploadAdditionalEvidenceHomeOffice",
+      "state": "respondentReview",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "No",
+          "addendumEvidenceDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "addendumEvidence",
+                "document": {
+                  "document_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79",
+                  "document_filename": "fake-doc.pdf",
+                  "document_binary_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79/binary"
+                },
+                "suppliedBy": "The respondent",
+                "description": "HO addendum 1",
+                "dateUploaded": "2023-09-26"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "isAcceleratedDetainedAppeal": "No",
+        "addendumEvidenceDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "addendumEvidence",
+              "document": {
+                "document_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79",
+                "document_filename": "fake-doc.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/653180d2-b004-4b7a-8293-69a39d5b8a79/binary"
+              },
+              "suppliedBy": "The respondent",
+              "description": "HO addendum 1",
+              "dateUploaded": "2023-09-26"
+            }
+          }
+        ],
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant letter_HO-evidence.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "homeOfficeUploadAdditionalAddendumEvidenceLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/functionalTest/resources/scenarios/RIA-7370-internal-detained-legal-officer-upload-addendum-evidence-supplied-by-ho.json
+++ b/src/functionalTest/resources/scenarios/RIA-7370-internal-detained-legal-officer-upload-addendum-evidence-supplied-by-ho.json
@@ -1,0 +1,78 @@
+{
+  "description": "RIA-7370 - Internal upload Legal Officer upload addendum evidence letter generation - Detained non-ada",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "uploadAddendumEvidence",
+      "state": "decided",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "Yes",
+          "isAcceleratedDetainedAppeal": "No",
+          "addendumEvidenceDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "addendumEvidence",
+                "document": {
+                  "document_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313",
+                  "document_filename": "fake-doc.pdf",
+                  "document_binary_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313/binary"
+                },
+                "suppliedBy": "The respondent",
+                "uploadedBy": "TCW",
+                "description": "k",
+                "dateUploaded": "2023-09-26"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "Yes",
+        "isAcceleratedDetainedAppeal": "No",
+        "addendumEvidenceDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "tag": "addendumEvidence",
+              "document": {
+                "document_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313",
+                "document_filename": "fake-doc.pdf",
+                "document_binary_url": "http://dm-store:8080/documents/bcc86de8-daca-4c16-b610-28bad91ba313/binary"
+              },
+              "suppliedBy": "The respondent",
+              "uploadedBy": "TCW",
+              "description": "k",
+              "dateUploaded": "2023-09-26"
+            }
+          }
+        ],
+        "notificationAttachmentDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-appellant letter_LO-evidence.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "legalOfficerUploadAdditionalEvidenceLetter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
@@ -66,6 +66,8 @@ public enum DocumentTag {
     MAINTAIN_CASE_LINK_APPEAL_LETTER("maintainCaseLinkAppealLetter", CaseType.ASYLUM),
     INTERNAL_UPLOAD_ADDITIONAL_EVIDENCE_LETTER("internalUploadAdditionalEvidenceLetter", CaseType.ASYLUM),
     INTERNAL_CHANGE_HEARING_CENTRE_LETTER("internalChangeHearingCentreLetter", CaseType.ASYLUM),
+    HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER("homeOfficeUploadAdditionalAddendumEvidenceLetter", CaseType.ASYLUM),
+    LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER("legalOfficerUploadAdditionalEvidenceLetter", CaseType.ASYLUM),
     AMEND_HOME_OFFICE_APPEAL_RESPONSE("amendHomeOfficeAppealResponse", CaseType.ASYLUM),
     INTERNAL_NON_STANDARD_DIRECTION_TO_APPELLANT_LETTER("internalNonStandardDirectionToAppellantLetter", CaseType.ASYLUM),
     INTERNAL_EDIT_APPEAL_LETTER("internalEditAppealLetter", CaseType.ASYLUM),

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentWithMetadata.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentWithMetadata.java
@@ -5,44 +5,59 @@ import static java.util.Objects.requireNonNull;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.HasDocument;
 
 @EqualsAndHashCode
 @ToString
-public class DocumentWithMetadata {
+public class DocumentWithMetadata implements HasDocument {
 
     private Document document;
     private String description;
     private String dateUploaded;
     private DocumentTag tag;
     private String suppliedBy;
+    private String uploadedBy;
 
     private DocumentWithMetadata() {
         // noop -- for deserializer
     }
 
     public DocumentWithMetadata(
-        Document document,
-        String description,
-        String dateUploaded,
-        DocumentTag tag
+            Document document,
+            String description,
+            String dateUploaded,
+            DocumentTag tag
     ) {
         this(document, description, dateUploaded, tag, null);
     }
 
     public DocumentWithMetadata(
-        Document document,
-        String description,
-        String dateUploaded,
-        DocumentTag tag,
-        String suppliedBy
+            Document document,
+            String description,
+            String dateUploaded,
+            DocumentTag tag,
+            String suppliedBy
+    ) {
+        this(document, description, dateUploaded, tag, suppliedBy, null);
+    }
+
+    public DocumentWithMetadata(
+            Document document,
+            String description,
+            String dateUploaded,
+            DocumentTag tag,
+            String suppliedBy,
+            String uploadedBy
     ) {
         this.document = document;
         this.description = description;
         this.dateUploaded = dateUploaded;
         this.tag = tag;
         this.suppliedBy = suppliedBy;
+        this.uploadedBy = uploadedBy;
     }
 
+    @Override
     public Document getDocument() {
         requireNonNull(document);
         return document;
@@ -64,5 +79,9 @@ public class DocumentWithMetadata {
 
     public String getSuppliedBy() {
         return suppliedBy;
+    }
+
+    public String getUploadedBy() {
+        return uploadedBy;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/Event.java
@@ -59,7 +59,9 @@ public enum Event {
     CHANGE_HEARING_CENTRE("changeHearingCentre", CaseType.ASYLUM),
     CREATE_CASE_LINK("createCaseLink", CaseType.ASYLUM),
     REQUEST_RESPONSE_AMEND("requestResponseAmend", CaseType.ASYLUM),
-
+    UPLOAD_ADDITIONAL_EVIDENCE_HOME_OFFICE("uploadAdditionalEvidenceHomeOffice", CaseType.ASYLUM),
+    UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE("uploadAddendumEvidenceHomeOffice", CaseType.ASYLUM),
+    UPLOAD_ADDENDUM_EVIDENCE("uploadAddendumEvidence", CaseType.ASYLUM),
     SUBMIT_APPLICATION("submitApplication", CaseType.BAIL),
     RECORD_THE_DECISION("recordTheDecision", CaseType.BAIL),
     END_APPLICATION("endApplication", CaseType.BAIL),

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/field/HasDocument.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/field/HasDocument.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field;
+
+public interface HasDocument {
+    Document getDocument();
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalUploadAdditionalEvidenceGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalUploadAdditionalEvidenceGenerator.java
@@ -1,38 +1,50 @@
 package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit.letter;
 
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.NOTIFICATION_ATTACHMENT_DOCUMENTS;
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event.UPLOAD_ADDENDUM_EVIDENCE_ADMIN_OFFICER;
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event.UPLOAD_ADDITIONAL_EVIDENCE;
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.isAppellantInDetention;
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.isInternalCase;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.*;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentWithMetadata;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
 
+
 @Component
 public class InternalUploadAdditionalEvidenceGenerator implements PreSubmitCallbackHandler<AsylumCase> {
 
-    private final DocumentCreator<AsylumCase> documentCreator;
+    private static final String LEGAL_OFFICER_ADDENDUM_UPLOADED_BY_LABEL = "TCW";
+    private static final String LEGAL_OFFICER_ADDENDUM_SUPPLIED_BY_LABEL = "The respondent";
+    private final DocumentCreator<AsylumCase> adminUploadEvidence;
+    private final DocumentCreator<AsylumCase> homeOfficeUploadEvidence;
+    private final DocumentCreator<AsylumCase> legalOfficereUploadEvidence;
     private final DocumentHandler documentHandler;
 
     public InternalUploadAdditionalEvidenceGenerator(
-        @Qualifier("internalUploadAdditionalEvidenceLetter") DocumentCreator<AsylumCase> documentCreator,
+        // First DocumentCreator bean represents admin upload however cannot rename as it will require too much refactoring
+        @Qualifier("internalUploadAdditionalEvidenceLetter") DocumentCreator<AsylumCase> adminUploadEvidence,
+        @Qualifier("internalHomeOfficeUploadAdditionalAddendumEvidenceLetter") DocumentCreator<AsylumCase> homeOfficeUploadEvidence,
+        @Qualifier("internalLegalOfficerUploadAdditionalEvidenceLetter") DocumentCreator<AsylumCase> legalOfficereUploadEvidence,
         DocumentHandler documentHandler
     ) {
-        this.documentCreator = documentCreator;
+        this.adminUploadEvidence = adminUploadEvidence;
+        this.homeOfficeUploadEvidence = homeOfficeUploadEvidence;
+        this.legalOfficereUploadEvidence = legalOfficereUploadEvidence;
         this.documentHandler = documentHandler;
     }
 
@@ -47,8 +59,33 @@ public class InternalUploadAdditionalEvidenceGenerator implements PreSubmitCallb
 
         Event event = callback.getEvent();
 
+        Optional<IdValue<DocumentWithMetadata>> latestAddendum;
+
+        if (event.equals(UPLOAD_ADDENDUM_EVIDENCE)) {
+            latestAddendum = getLatestAddendumEvidenceDocument(asylumCase);
+            if (latestAddendum.isEmpty()) {
+                return false;
+            }
+
+            DocumentWithMetadata addendum = latestAddendum.get().getValue();
+
+            if (!addendum.getUploadedBy().equals(LEGAL_OFFICER_ADDENDUM_UPLOADED_BY_LABEL)) {
+                return false;
+            }
+
+            if (!addendum.getSuppliedBy().equals(LEGAL_OFFICER_ADDENDUM_SUPPLIED_BY_LABEL)) {
+                return false;
+            }
+        }
+
         return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
-               && List.of(UPLOAD_ADDITIONAL_EVIDENCE, UPLOAD_ADDENDUM_EVIDENCE_ADMIN_OFFICER).contains(event)
+               && List.of(
+                   UPLOAD_ADDITIONAL_EVIDENCE,
+                   UPLOAD_ADDENDUM_EVIDENCE,
+                   UPLOAD_ADDENDUM_EVIDENCE_ADMIN_OFFICER,
+                   UPLOAD_ADDITIONAL_EVIDENCE_HOME_OFFICE,
+                   UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE)
+                .contains(event)
                && isInternalCase(asylumCase)
                && isAppellantInDetention(asylumCase);
     }
@@ -64,13 +101,25 @@ public class InternalUploadAdditionalEvidenceGenerator implements PreSubmitCallb
         final CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
         final AsylumCase asylumCase = caseDetails.getCaseData();
 
-        Document internalUploadAdditionalEvidenceLetter = documentCreator.create(caseDetails);
+        Document documentToUpload;
+        DocumentTag documentTagForUpload;
+
+        if (List.of(UPLOAD_ADDITIONAL_EVIDENCE_HOME_OFFICE, UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE).contains(callback.getEvent())) {
+            documentToUpload = homeOfficeUploadEvidence.create(caseDetails);
+            documentTagForUpload = HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER;
+        } else if (callback.getEvent().equals(UPLOAD_ADDENDUM_EVIDENCE)) {
+            documentToUpload = legalOfficereUploadEvidence.create(caseDetails);
+            documentTagForUpload = LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER;
+        } else {
+            documentToUpload = adminUploadEvidence.create(caseDetails);
+            documentTagForUpload = DocumentTag.INTERNAL_UPLOAD_ADDITIONAL_EVIDENCE_LETTER;
+        }
 
         documentHandler.addWithMetadataWithoutReplacingExistingDocuments(
             asylumCase,
-            internalUploadAdditionalEvidenceLetter,
+            documentToUpload,
             NOTIFICATION_ATTACHMENT_DOCUMENTS,
-            DocumentTag.INTERNAL_UPLOAD_ADDITIONAL_EVIDENCE_LETTER
+            documentTagForUpload
         );
 
         return new PreSubmitCallbackResponse<>(asylumCase);

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
@@ -189,6 +189,12 @@ public class BundleOrder implements Comparator<DocumentWithMetadata> {
             case INTERNAL_EDIT_APPEAL_LETTER:
                 log.warn("INTERNAL_EDIT_APPEAL_LETTER tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
                 return 63;
+            case HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER:
+                log.warn("HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
+                return 64;
+            case LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER:
+                log.warn("LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
+                return 65;
             default:
                 throw new IllegalStateException("document has unknown tag: " + document.getTag() + ", description: " + document.getDescription());
         }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.getAppellantPersonalisation;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.DocumentTemplate;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+
+
+@Component
+public class InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate implements DocumentTemplate<AsylumCase> {
+
+    private final String templateName;
+    private final CustomerServicesProvider customerServicesProvider;
+
+    public InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate(
+            @Value("${internalHomeOfficeUploadAdditionalAddendumEvidence.templateName}") String templateName,
+            CustomerServicesProvider customerServicesProvider) {
+        this.templateName = templateName;
+        this.customerServicesProvider = customerServicesProvider;
+    }
+
+    @Override
+    public String getName() {
+        return templateName;
+    }
+
+    public Map<String, Object> mapFieldValues(
+            CaseDetails<AsylumCase> caseDetails
+    ) {
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        final Map<String, Object> fieldValues = new HashMap<>();
+
+        fieldValues.putAll(getAppellantPersonalisation(asylumCase));
+        fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase));
+        fieldValues.put("customerServicesEmail", customerServicesProvider.getInternalCustomerServicesEmail(asylumCase));
+        fieldValues.put("dateLetterSent", formatDateForNotificationAttachmentDocument(LocalDate.now()));
+        return fieldValues;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.getAppellantPersonalisation;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.DocumentTemplate;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+
+
+@Component
+public class InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate implements DocumentTemplate<AsylumCase> {
+
+    private final String templateName;
+    private final CustomerServicesProvider customerServicesProvider;
+
+    public InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate(
+            @Value("${internalLegalOfficerUploadAdditionalEvidence.templateName}") String templateName,
+            CustomerServicesProvider customerServicesProvider) {
+        this.templateName = templateName;
+        this.customerServicesProvider = customerServicesProvider;
+    }
+
+    @Override
+    public String getName() {
+        return templateName;
+    }
+
+    public Map<String, Object> mapFieldValues(
+            CaseDetails<AsylumCase> caseDetails
+    ) {
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        final Map<String, Object> fieldValues = new HashMap<>();
+
+        fieldValues.putAll(getAppellantPersonalisation(asylumCase));
+        fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase));
+        fieldValues.put("customerServicesEmail", customerServicesProvider.getInternalCustomerServicesEmail(asylumCase));
+        fieldValues.put("dateLetterSent", formatDateForNotificationAttachmentDocument(LocalDate.now()));
+        return fieldValues;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/utils/AsylumCaseUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/utils/AsylumCaseUtils.java
@@ -17,12 +17,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.RequiredFieldMissingException;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.*;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.DirectionFinder;
+
 
 public class AsylumCaseUtils {
 
@@ -159,5 +159,27 @@ public class AsylumCaseUtils {
                 .findFirst(asylumCase, directionTag)
                 .map(direction -> direction.getParties().equals(parties))
                 .orElse(false);
+    }
+
+    public static List<IdValue<DocumentWithMetadata>> getAddendumEvidenceDocuments(AsylumCase asylumCase) {
+        Optional<List<IdValue<DocumentWithMetadata>>> maybeExistingAdditionalEvidenceDocuments =
+                asylumCase.read(ADDENDUM_EVIDENCE_DOCUMENTS);
+        if (maybeExistingAdditionalEvidenceDocuments.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return maybeExistingAdditionalEvidenceDocuments.get();
+    }
+
+
+    public static Optional<IdValue<DocumentWithMetadata>> getLatestAddendumEvidenceDocument(AsylumCase asylumCase) {
+        List<IdValue<DocumentWithMetadata>> addendums = getAddendumEvidenceDocuments(asylumCase);
+
+        if (addendums.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<IdValue<DocumentWithMetadata>> optionalLatestAddendum = addendums.stream().findFirst();
+        return Optional.of(optionalLatestAddendum.get());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
@@ -1297,6 +1297,48 @@ public class DocumentCreatorConfiguration {
         );
     }
 
+    @Bean("internalHomeOfficeUploadAdditionalAddendumEvidenceLetter")
+    public DocumentCreator<AsylumCase> getInternalHomeOfficeUploadAdditionalAddendumEvidenceLetterCreator(
+            @Value("${internalHomeOfficeUploadAdditionalAddendumEvidence.contentType}") String contentType,
+            @Value("${internalHomeOfficeUploadAdditionalAddendumEvidence.fileExtension}") String fileExtension,
+            @Value("${internalHomeOfficeUploadAdditionalAddendumEvidence.fileName}") String fileName,
+            AsylumCaseFileNameQualifier fileNameQualifier,
+            InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate documentTemplate,
+            DocumentGenerator documentGenerator,
+            DocumentUploader documentUploader
+    ) {
+        return new DocumentCreator<>(
+                contentType,
+                fileExtension,
+                fileName,
+                fileNameQualifier,
+                documentTemplate,
+                documentGenerator,
+                documentUploader
+        );
+    }
+
+    @Bean("internalLegalOfficerUploadAdditionalEvidenceLetter")
+    public DocumentCreator<AsylumCase> getInternalLegalOfficerUploadAdditionalEvidenceLetterCreator(
+            @Value("${internalLegalOfficerUploadAdditionalEvidence.contentType}") String contentType,
+            @Value("${internalLegalOfficerUploadAdditionalEvidence.fileExtension}") String fileExtension,
+            @Value("${internalLegalOfficerUploadAdditionalEvidence.fileName}") String fileName,
+            AsylumCaseFileNameQualifier fileNameQualifier,
+            InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate documentTemplate,
+            DocumentGenerator documentGenerator,
+            DocumentUploader documentUploader
+    ) {
+        return new DocumentCreator<>(
+                contentType,
+                fileExtension,
+                fileName,
+                fileNameQualifier,
+                documentTemplate,
+                documentGenerator,
+                documentUploader
+        );
+    }
+
     @Bean("internalMaintainCaseLinkAppealLetter")
     public DocumentCreator<AsylumCase> getInternalMaintainCaseLinkAppealLetterCreator(
         @Value("${internalDetainedMaintainCaseLinkAppeal.contentType}") String contentType,

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -388,6 +388,16 @@ internalChangeHearingCentreLetter.fileExtension: PDF
 internalChangeHearingCentreLetter.fileName: "appellant-change-hearing-centre-letter"
 internalChangeHearingCentreLetter.templateName: ${IA_INTERNAL_CHANGE_HEARING_CENTRE_TEMPLATE:TB-IAC-LET-ENG-00032.docx}
 
+internalHomeOfficeUploadAdditionalAddendumEvidence.contentType:  application/pdf
+internalHomeOfficeUploadAdditionalAddendumEvidence.fileExtension: PDF
+internalHomeOfficeUploadAdditionalAddendumEvidence.fileName: "appellant letter_HO-evidence"
+internalHomeOfficeUploadAdditionalAddendumEvidence.templateName: ${IA_INTERNAL_HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_TEMPLATE:TB-IAC-LET-ENG-00035.docx}
+
+internalLegalOfficerUploadAdditionalEvidence.contentType:  application/pdf
+internalLegalOfficerUploadAdditionalEvidence.fileExtension: PDF
+internalLegalOfficerUploadAdditionalEvidence.fileName: "appellant letter_LO-evidence"
+internalLegalOfficerUploadAdditionalEvidence.templateName: ${IA_INTERNAL_LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_TEMPLATE:TB-IAC-LET-ENG-00036.docx}
+
 internalDetainedMaintainCaseLinkAppeal.contentType:  application/pdf
 internalDetainedMaintainCaseLinkAppeal.fileExtension: PDF
 internalDetainedMaintainCaseLinkAppeal.fileName: "detained-appellant-maintain-case-link-appeal-notice"
@@ -491,6 +501,7 @@ security:
       - "changeHearingCentre"
       - "createCaseLink"
       - "requestResponseAmend"
+      - "uploadAddendumEvidence"
     caseworker-ia-admofficer:
       - "listCase"
       - "submitAppeal"
@@ -555,10 +566,16 @@ security:
       - "endAppealAutomatically"
     caseworker-ia-homeofficelart:
       - "uploadHomeOfficeAppealResponse"
+      - "uploadAdditionalEvidenceHomeOffice"
+      - "uploadAddendumEvidenceHomeOffice"
     caseworker-ia-homeofficepou:
       - "applyForFTPARespondent"
+      - "uploadAdditionalEvidenceHomeOffice"
+      - "uploadAddendumEvidenceHomeOffice"
     caseworker-ia-respondentofficer:
       - "applyForFTPARespondent"
+      - "uploadAdditionalEvidenceHomeOffice"
+      - "uploadAddendumEvidenceHomeOffice"
 
 ### dependency configuration
 core_case_data_api_url: ${CCD_URL:http://127.0.0.1:4452}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
@@ -71,11 +71,12 @@ class DocumentTagTest {
         assertEquals("amendHomeOfficeAppealResponse", DocumentTag.AMEND_HOME_OFFICE_APPEAL_RESPONSE.toString());
         assertEquals("internalNonStandardDirectionToAppellantLetter", DocumentTag.INTERNAL_NON_STANDARD_DIRECTION_TO_APPELLANT_LETTER.toString());
         assertEquals("internalEditAppealLetter", DocumentTag.INTERNAL_EDIT_APPEAL_LETTER.toString());
-
+        assertEquals("homeOfficeUploadAdditionalAddendumEvidenceLetter", DocumentTag.HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER.toString());
+        assertEquals("legalOfficerUploadAdditionalEvidenceLetter", DocumentTag.LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER.toString());
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(71, DocumentTag.values().length);
+        assertEquals(73, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentWithMetadataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentWithMetadataTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.mock;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
 
-public class DocumentWithMetadataTest {
+class DocumentWithMetadataTest {
 
     private final Document document = mock(Document.class);
     private final String description = "Some evidence";
@@ -14,19 +14,20 @@ public class DocumentWithMetadataTest {
     private final DocumentTag tag = DocumentTag.CASE_ARGUMENT;
 
     private DocumentWithMetadata documentWithMetadata =
-        new DocumentWithMetadata(
-            document,
-            description,
-            dateUploaded,
-            tag,"test"
-        );
+            new DocumentWithMetadata(
+                    document,
+                    description,
+                    dateUploaded,
+                    tag
+            );
 
     @Test
-    public void should_hold_onto_values() {
+    void should_hold_onto_values() {
 
         assertEquals(document, documentWithMetadata.getDocument());
         assertEquals(description, documentWithMetadata.getDescription());
         assertEquals(dateUploaded, documentWithMetadata.getDateUploaded());
         assertEquals(tag, documentWithMetadata.getTag());
     }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/ccd/EventTest.java
@@ -66,10 +66,13 @@ public class EventTest {
         assertEquals("changeHearingCentre", Event.CHANGE_HEARING_CENTRE.toString());
         assertEquals("createCaseLink", Event.CREATE_CASE_LINK.toString());
         assertEquals("requestResponseAmend", Event.REQUEST_RESPONSE_AMEND.toString());
+        assertEquals("uploadAdditionalEvidenceHomeOffice", Event.UPLOAD_ADDITIONAL_EVIDENCE_HOME_OFFICE.toString());
+        assertEquals("uploadAddendumEvidenceHomeOffice", Event.UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE.toString());
+        assertEquals("uploadAddendumEvidence", Event.UPLOAD_ADDENDUM_EVIDENCE.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(61, Event.values().length);
+        assertEquals(64, Event.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalUploadAdditionalEvidenceGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalUploadAdditionalEvidenceGeneratorTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.IS_ADMIN;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,15 +21,18 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentWithMetadata;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("unchecked")
@@ -34,7 +40,11 @@ import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
 class InternalUploadAdditionalEvidenceGeneratorTest {
 
     @Mock
-    private DocumentCreator<AsylumCase> documentCreator;
+    private DocumentCreator<AsylumCase> adminUploadEvidenceDocumentCreator;
+    @Mock
+    private DocumentCreator<AsylumCase> homeOfficeUploadEvidenceDocumentCreator;
+    @Mock
+    private DocumentCreator<AsylumCase> legalOfficereUploadEvidenceDocumentCreator;
     @Mock
     private DocumentHandler documentHandler;
     @Mock
@@ -46,27 +56,50 @@ class InternalUploadAdditionalEvidenceGeneratorTest {
     @Mock
     private Document uploadedDocument;
 
+    private static final String LEGAL_OFFICER_ADDENDUM_SUPPLIED_BY_LABEL = "The respondent";
+    private static final String LEGAL_OFFICER_ADDENDUM_UPLOADED_BY_LABEL = "TCW";
+
+    private final IdValue<DocumentWithMetadata> addendumOne = new IdValue<>(
+            "1",
+            new DocumentWithMetadata(
+                    uploadedDocument,
+                    "Some description",
+                    "2018-12-25", DocumentTag.ADDENDUM_EVIDENCE,
+                    LEGAL_OFFICER_ADDENDUM_SUPPLIED_BY_LABEL,
+                    LEGAL_OFFICER_ADDENDUM_UPLOADED_BY_LABEL
+            )
+    );
+
     private InternalUploadAdditionalEvidenceGenerator internalUploadAdditionalEvidenceGenerator;
 
     @BeforeEach
     void setUp() {
         internalUploadAdditionalEvidenceGenerator =
-            new InternalUploadAdditionalEvidenceGenerator(documentCreator, documentHandler);
+            new InternalUploadAdditionalEvidenceGenerator(
+                    adminUploadEvidenceDocumentCreator,
+                    homeOfficeUploadEvidenceDocumentCreator,
+                    legalOfficereUploadEvidenceDocumentCreator,
+                    documentHandler
+            );
+
+        when(callback.getEvent()).thenReturn(Event.UPLOAD_ADDITIONAL_EVIDENCE_HOME_OFFICE);
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getCaseDetails().getCaseData().read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
     }
 
     @ParameterizedTest
     @EnumSource(value = Event.class, names = {"UPLOAD_ADDITIONAL_EVIDENCE", "UPLOAD_ADDENDUM_EVIDENCE_ADMIN_OFFICER"})
-    void should_create_internal_upload_additional_evidence_letter_pdf_and_append_to_notifications_documents(Event event) {
-        when(callback.getCaseDetails()).thenReturn(caseDetails);
-        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+    void should_create_internal_admin_upload_additional_evidence_letter_pdf_and_append_to_notifications_documents(Event event) {
         when(callback.getEvent()).thenReturn(event);
-        when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-        when(callback.getCaseDetails().getCaseData().read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 
-        when(documentCreator.create(caseDetails)).thenReturn(uploadedDocument);
+        when(adminUploadEvidenceDocumentCreator.create(caseDetails)).thenReturn(uploadedDocument);
 
         PreSubmitCallbackResponse<AsylumCase> callbackResponse =
-            internalUploadAdditionalEvidenceGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+            internalUploadAdditionalEvidenceGenerator.handle(ABOUT_TO_SUBMIT, callback);
 
         assertNotNull(callbackResponse);
         assertEquals(asylumCase, callbackResponse.getData());
@@ -75,6 +108,50 @@ class InternalUploadAdditionalEvidenceGeneratorTest {
             asylumCase, uploadedDocument,
             NOTIFICATION_ATTACHMENT_DOCUMENTS,
             DocumentTag.INTERNAL_UPLOAD_ADDITIONAL_EVIDENCE_LETTER
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = {"UPLOAD_ADDITIONAL_EVIDENCE_HOME_OFFICE", "UPLOAD_ADDENDUM_EVIDENCE_HOME_OFFICE"})
+    void should_create_internal_home_office_upload_additional_evidence_letter_pdf_and_append_to_notifications_documents(Event event) {
+        when(callback.getEvent()).thenReturn(event);
+
+        when(homeOfficeUploadEvidenceDocumentCreator.create(caseDetails)).thenReturn(uploadedDocument);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                internalUploadAdditionalEvidenceGenerator.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(documentHandler, times(1)).addWithMetadataWithoutReplacingExistingDocuments(
+                asylumCase, uploadedDocument,
+                NOTIFICATION_ATTACHMENT_DOCUMENTS,
+                DocumentTag.HOME_OFFICE_UPLOAD_ADDITIONAL_ADDENDUM_EVIDENCE_LETTER
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Event.class, names = {"UPLOAD_ADDENDUM_EVIDENCE"})
+    void should_create_internal_legal_officer_upload_additional_evidence_letter_pdf_and_append_to_notifications_documents(Event event) {
+        when(callback.getEvent()).thenReturn(event);
+
+        List<IdValue<DocumentWithMetadata>> addendumDocuments = new ArrayList<>();
+        addendumDocuments.add(addendumOne);
+        when(asylumCase.read(ADDENDUM_EVIDENCE_DOCUMENTS)).thenReturn(Optional.of(addendumDocuments));
+
+        when(legalOfficereUploadEvidenceDocumentCreator.create(caseDetails)).thenReturn(uploadedDocument);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+                internalUploadAdditionalEvidenceGenerator.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(documentHandler, times(1)).addWithMetadataWithoutReplacingExistingDocuments(
+                asylumCase, uploadedDocument,
+                NOTIFICATION_ATTACHMENT_DOCUMENTS,
+                DocumentTag.LEGAL_OFFICER_UPLOAD_ADDITIONAL_EVIDENCE_LETTER
         );
     }
 
@@ -89,45 +166,31 @@ class InternalUploadAdditionalEvidenceGeneratorTest {
 
         when(callback.getEvent()).thenReturn(Event.START_APPEAL);
 
-        assertThatThrownBy(() -> internalUploadAdditionalEvidenceGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+        assertThatThrownBy(() -> internalUploadAdditionalEvidenceGenerator.handle(ABOUT_TO_SUBMIT, callback))
             .hasMessage("Cannot handle callback")
             .isExactlyInstanceOf(IllegalStateException.class);
     }
 
     @Test
-    void it_cannot_handle_callback_if_is_admin_is_missing() {
+    void it_cannot_handle_callback_if_not_internal() {
+        when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
 
-        for (Event event : Event.values()) {
-
-            when(callback.getEvent()).thenReturn(event);
-            when(callback.getCaseDetails()).thenReturn(caseDetails);
-            when(caseDetails.getCaseData()).thenReturn(asylumCase);
-            when(callback.getCaseDetails().getCaseData().read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-
-            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
-                boolean canHandle = internalUploadAdditionalEvidenceGenerator.canHandle(callbackStage, callback);
-                assertFalse(canHandle);
-            }
-            reset(callback);
-        }
+        assertFalse(internalUploadAdditionalEvidenceGenerator.canHandle(ABOUT_TO_SUBMIT, callback));
     }
 
     @Test
-    void it_cannot_handle_callback_if_is_detained_is_missing() {
+    void it_cannot_handle_callback_if_appellant_is_not_in_detention() {
+        when(callback.getCaseDetails().getCaseData().read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
 
-        for (Event event : Event.values()) {
+        assertFalse(internalUploadAdditionalEvidenceGenerator.canHandle(ABOUT_TO_SUBMIT, callback));
+    }
 
-            when(callback.getEvent()).thenReturn(event);
-            when(callback.getCaseDetails()).thenReturn(caseDetails);
-            when(caseDetails.getCaseData()).thenReturn(asylumCase);
-            when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+    @ParameterizedTest
+    @EnumSource(value = YesOrNo.class)
+    void it_should_handle_both_detained_non_ada_and_detained_ada_cases(YesOrNo yesOrNo) {
+        when(callback.getCaseDetails().getCaseData().read(IS_ACCELERATED_DETAINED_APPEAL, YesOrNo.class)).thenReturn(Optional.of(yesOrNo));
 
-            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
-                boolean canHandle = internalUploadAdditionalEvidenceGenerator.canHandle(callbackStage, callback);
-                assertFalse(canHandle);
-            }
-            reset(callback);
-        }
+        assertTrue(internalUploadAdditionalEvidenceGenerator.canHandle(ABOUT_TO_SUBMIT, callback));
     }
 
     @Test
@@ -137,7 +200,7 @@ class InternalUploadAdditionalEvidenceGeneratorTest {
             .hasMessage("callbackStage must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
 
-        assertThatThrownBy(() -> internalUploadAdditionalEvidenceGenerator.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+        assertThatThrownBy(() -> internalUploadAdditionalEvidenceGenerator.canHandle(ABOUT_TO_SUBMIT, null))
             .hasMessage("callback must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
 
@@ -145,7 +208,7 @@ class InternalUploadAdditionalEvidenceGeneratorTest {
             .hasMessage("callbackStage must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
 
-        assertThatThrownBy(() -> internalUploadAdditionalEvidenceGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+        assertThatThrownBy(() -> internalUploadAdditionalEvidenceGenerator.handle(ABOUT_TO_SUBMIT, null))
             .hasMessage("callback must not be null")
             .isExactlyInstanceOf(NullPointerException.class);
     }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
@@ -37,7 +37,7 @@ public class BundleOrderTest {
             .map(DocumentWithMetadata::getTag)
             .collect(Collectors.toList());
 
-        assertEquals(65, sortedTags.size());
+        assertEquals(67, sortedTags.size());
 
         List<DocumentTag> documentTagList = Arrays.asList(
             DocumentTag.CASE_SUMMARY,

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplateTest.java
@@ -1,0 +1,85 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplateTest {
+
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private CustomerServicesProvider customerServicesProvider;
+    private InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate internalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate;
+    private final String templateName = "TB-IAC-LET-ENG-00035.docx";
+    private final String appealReferenceNumber = "HU/11111/2023";
+    private final String homeOfficeReferenceNumber = "A1234567/001";
+    private final String appellantGivenNames = "John";
+    private final String appellantFamilyName = "Doe";
+    private final LocalDate now = LocalDate.now();
+    private final String customerServicesTelephone = "0300 123 1711";
+    private final String customerServicesEmail = "email@example.com";
+
+    @BeforeEach
+    void setUp() {
+        internalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate =
+                new InternalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate(
+                        templateName,
+                        customerServicesProvider
+                );
+    }
+
+    @Test
+    void should_return_template_name() {
+
+        assertEquals(templateName, internalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate.getName());
+    }
+
+    void dataSetUp() {
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase)).thenReturn(customerServicesTelephone);
+        when(customerServicesProvider.getInternalCustomerServicesEmail(asylumCase)).thenReturn(customerServicesEmail);
+    }
+
+    @Test
+    void should_map_case_data_to_template_field_values() {
+        dataSetUp();
+
+        Map<String, Object> templateFieldValues = internalHomeOfficeUploadAdditionalAndAddendumEvidenceTemplate.mapFieldValues(caseDetails);
+
+        assertEquals(8, templateFieldValues.size());
+        assertEquals(appealReferenceNumber, templateFieldValues.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, templateFieldValues.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, templateFieldValues.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, templateFieldValues.get("appellantFamilyName"));
+        assertEquals(formatDateForNotificationAttachmentDocument(now), templateFieldValues.get("dateLetterSent"));
+        assertEquals(customerServicesTelephone, templateFieldValues.get("customerServicesTelephone"));
+        assertEquals(customerServicesEmail, templateFieldValues.get("customerServicesEmail"));
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplateTest.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.APPELLANT_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplateTest {
+
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock private AsylumCase asylumCase;
+    @Mock private CustomerServicesProvider customerServicesProvider;
+    private InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate internalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate;
+    private final String templateName = "TB-IAC-LET-ENG-00036.docx";
+    private final String appealReferenceNumber = "HU/11111/2023";
+    private final String homeOfficeReferenceNumber = "A1234567/001";
+    private final String appellantGivenNames = "John";
+    private final String appellantFamilyName = "Doe";
+    private final LocalDate now = LocalDate.now();
+    private final String customerServicesTelephone = "0300 123 1711";
+    private final String customerServicesEmail = "email@example.com";
+
+    @BeforeEach
+    void setUp() {
+        internalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate =
+                new InternalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate(
+                        templateName,
+                        customerServicesProvider
+                );
+    }
+
+    @Test
+    void should_return_template_name() {
+
+        assertEquals(templateName, internalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate.getName());
+    }
+
+    void dataSetUp() {
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase)).thenReturn(customerServicesTelephone);
+        when(customerServicesProvider.getInternalCustomerServicesEmail(asylumCase)).thenReturn(customerServicesEmail);
+    }
+
+    @Test
+    void should_map_case_data_to_template_field_values() {
+        dataSetUp();
+
+        Map<String, Object> templateFieldValues = internalLegalOfficerUploadAdditionalAndAddendumEvidenceTemplate.mapFieldValues(caseDetails);
+
+        assertEquals(8, templateFieldValues.size());
+        assertEquals(appealReferenceNumber, templateFieldValues.get("appealReferenceNumber"));
+        assertEquals(homeOfficeReferenceNumber, templateFieldValues.get("homeOfficeReferenceNumber"));
+        assertEquals(appellantGivenNames, templateFieldValues.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, templateFieldValues.get("appellantFamilyName"));
+        assertEquals(formatDateForNotificationAttachmentDocument(now), templateFieldValues.get("dateLetterSent"));
+        assertEquals(customerServicesTelephone, templateFieldValues.get("customerServicesTelephone"));
+        assertEquals(customerServicesEmail, templateFieldValues.get("customerServicesEmail"));
+    }
+
+
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/RIA-7370


### Change description ###
* Refactored implementation of RIA-7427 to make InternalUploadAdditionalEvidenceGenerator generic for all users
* Imported HasDocument interface and made current implementation of DocumentWithMetadata implement it
* Imported events from case-api
* Added 2 new doc tags (LO additional evidence upload and HO additional evidence upload)
* Created 2 new templates for HO and LO additional evidence upload
* Added new methods in AsylumCaseUtils to extract addendum evidence documents and to fetch most recent addendum evidence added
* Created 2 new beans in DocumentCreatorConfiguration (LO/HO additional evidence upload)
* 2 new application.yaml entries for document templates
* Updated existing tests and added new unit/FTs

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
