### PR TITLE
DIAC-2 Updated Renovate config file, added automerge, scheduling and package…

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":dependencyDashboard"],
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "automerge": true
+    }
+  ],
+  "schedule": [
+    "3am"
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":dependencyDashboard"],
+  "extends": ["local>hmcts/.github:renovate-config"],
   "labels": ["dependencies"],
   "packageRules": [
     {

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ def versions = [
     pitest             : '1.9.0',
     reformLogging      : '5.1.7',
     reformHealthStarter: '0.0.5',
-    restAssured        : '5.3.1',
+    restAssured        : '5.3.0',
     serenity           : '3.6.22',
     sonarPitest        : '0.5',
     springHystrix      : '2.2.10.RELEASE',

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -20,7 +20,7 @@
         ]]</notes>
         <cve>CVE-2022-45688</cve>
     </suppress>
-    <suppress until="2023-09-30">
+    <suppress until="2023-10-30">
         <cve>CVE-2023-35116</cve><!-- 2023-09-04 jackson-databind 2.15.2 (the latest version at time of checking) is still vulnerable. Try again when a new version comes out. -->
     </suppress>
 </suppressions>


### PR DESCRIPTION
… types. Also backdated restAssured from 5.3.1 to 5.3.0 to test Renovate

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DIAC-2

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
