### PR TITLE
RIA-8119 Bail application document changes with added interpreter fields

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -31,5 +31,7 @@
         <cve>CVE-2023-44487</cve>
         <cve>CVE-2023-42795</cve>
         <cve>CVE-2023-45648</cve>
+        <cve>CVE-2023-6481</cve>
+        <cve>CVE-2023-34055</cve>
     </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -33,5 +33,8 @@
         <cve>CVE-2023-45648</cve>
         <cve>CVE-2023-6481</cve>
         <cve>CVE-2023-34055</cve>
+        <cve>CVE-2023-33202</cve>
+        <cve>CVE-2023-46589</cve>
+        <cve>CVE-2023-6378</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/BailCaseFieldDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/BailCaseFieldDefinition.java
@@ -297,6 +297,38 @@ public enum BailCaseFieldDefinition {
         "uploadSignedDecisionNoticeDocument", new TypeReference<Document>(){}),
     SIGNED_DECISION_DOCUMENT_WITH_METADATA(
         "signDecisionDocumentWithMetadata", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
+    APPLICANT_INTERPRETER_SPOKEN_LANGUAGE(
+        "applicantInterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+    APPLICANT_INTERPRETER_SIGN_LANGUAGE(
+        "applicantInterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+    APPLICANT_INTERPRETER_LANGUAGE_CATEGORY(
+        "applicantInterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+    FCS_INTERPRETER_YES_NO(
+        "fcsInterpreterYesNo", new TypeReference<YesOrNo>(){}),
+    FCS1_INTERPRETER_LANGUAGE_CATEGORY(
+        "fcs1InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+    FCS1_INTERPRETER_SPOKEN_LANGUAGE(
+        "fcs1InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+    FCS1_INTERPRETER_SIGN_LANGUAGE(
+        "fcs1InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+    FCS2_INTERPRETER_LANGUAGE_CATEGORY(
+        "fcs2InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+    FCS2_INTERPRETER_SPOKEN_LANGUAGE(
+        "fcs2InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+    FCS2_INTERPRETER_SIGN_LANGUAGE(
+        "fcs2InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+    FCS3_INTERPRETER_LANGUAGE_CATEGORY(
+        "fcs3InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+    FCS3_INTERPRETER_SPOKEN_LANGUAGE(
+        "fcs3InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+    FCS3_INTERPRETER_SIGN_LANGUAGE(
+        "fcs3InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+    FCS4_INTERPRETER_LANGUAGE_CATEGORY(
+        "fcs4InterpreterLanguageCategory", new TypeReference<List<String>>() {}),
+    FCS4_INTERPRETER_SPOKEN_LANGUAGE(
+        "fcs4InterpreterSpokenLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
+    FCS4_INTERPRETER_SIGN_LANGUAGE(
+        "fcs4InterpreterSignLanguage", new TypeReference<InterpreterLanguageRefData>() {}),
     ;
 
     private final String value;

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/InterpreterLanguageCategory.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/InterpreterLanguageCategory.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities;
+
+public enum InterpreterLanguageCategory {
+
+    SPOKEN_LANGUAGE_INTERPRETER("spokenLanguageInterpreter"),
+    SIGN_LANGUAGE_INTERPRETER("signLanguageInterpreter");
+
+    private final String value;
+
+    InterpreterLanguageCategory(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return getValue();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/bail/BailSubmissionTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/bail/BailSubmissionTemplate.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.bail;
 
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.BailCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.InterpreterLanguageCategory.SIGN_LANGUAGE_INTERPRETER;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.InterpreterLanguageCategory.SPOKEN_LANGUAGE_INTERPRETER;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -17,6 +19,7 @@ import lombok.NonNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.BailCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.InterpreterLanguageRefData;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.PriorApplication;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.AddressUk;
@@ -33,6 +36,8 @@ public class BailSubmissionTemplate implements DocumentTemplate<BailCase> {
     private static final String SENT_BY_LR = "Legal Representative";
     private static final String SENT_BY_HO = "Home Office";
     private static final String NATIONALITY = "nationality";
+    private static final String SPOKEN_INTERPRETER_LABEL = "Spoken language interpreter";
+    private static final String SIGN_INTERPRETER_LABEL = "Sign language interpreter";
 
     private final String templateName;
 
@@ -202,6 +207,17 @@ public class BailSubmissionTemplate implements DocumentTemplate<BailCase> {
 
         if (bailCase.read(PRIOR_APPLICATIONS, PriorApplication.class).orElse(null) == null) {
             fieldValues.put("showPreviousApplicationSection", YesOrNo.YES);
+        }
+
+        setApplicantInterpreterLanguageDetails(bailCase, fieldValues);
+
+        fieldValues.put("fcsInterpreterYesNo", bailCase.read(FCS_INTERPRETER_YES_NO, YesOrNo.class).orElse(YesOrNo.NO));
+
+        if (bailCase.read(FCS_INTERPRETER_YES_NO, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.YES) {
+            setFcs1InterpreterLanguageDetails(bailCase, fieldValues);
+            setFcs2InterpreterLanguageDetails(bailCase, fieldValues);
+            setFcs3InterpreterLanguageDetails(bailCase, fieldValues);
+            setFcs4InterpreterLanguageDetails(bailCase, fieldValues);
         }
 
         return fieldValues;
@@ -424,6 +440,203 @@ public class BailSubmissionTemplate implements DocumentTemplate<BailCase> {
         fieldValues.put("videoHearing1", bailCase.read(VIDEO_HEARING1, YesOrNo.class).orElse(YesOrNo.NO));
         if (bailCase.read(VIDEO_HEARING1, YesOrNo.class).orElse(YesOrNo.NO) == YesOrNo.NO) {
             fieldValues.put("videoHearingDetails", bailCase.read(VIDEO_HEARING_DETAILS, String.class).orElse(""));
+        }
+    }
+
+    private void setApplicantInterpreterLanguageDetails(BailCase bailCase, Map<String, Object> fieldValues) {
+
+        Optional<List<String>> languageCategoriesOptional = bailCase
+            .read(APPLICANT_INTERPRETER_LANGUAGE_CATEGORY);
+
+        if (languageCategoriesOptional.isPresent()) {
+            List<String> languageCategories = languageCategoriesOptional.get();
+
+            if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())
+                && languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("applicantInterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL + "\n" + SIGN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("applicantInterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("applicantInterpreterLanguageCategory", SIGN_INTERPRETER_LABEL);
+            }
+
+            Optional<InterpreterLanguageRefData> applicantSpokenInterpreterLanguage = bailCase.read(APPLICANT_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+            Optional<InterpreterLanguageRefData> applicantSignInterpreterLanguage = bailCase.read(APPLICANT_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+
+            applicantSpokenInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("applicantInterpreterSpokenLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("applicantInterpreterSpokenLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
+
+            applicantSignInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("applicantInterpreterSignLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("applicantInterpreterSignLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
+        }
+    }
+
+    private void setFcs1InterpreterLanguageDetails(BailCase bailCase, Map<String, Object> fieldValues) {
+
+        Optional<List<String>> languageCategoriesOptional = bailCase
+            .read(FCS1_INTERPRETER_LANGUAGE_CATEGORY);
+
+        if (languageCategoriesOptional.isPresent()) {
+            List<String> languageCategories = languageCategoriesOptional.get();
+
+            if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())
+                && languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs1InterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL + "\n" + SIGN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs1InterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs1InterpreterLanguageCategory", SIGN_INTERPRETER_LABEL);
+            }
+
+            Optional<InterpreterLanguageRefData> fcs1SpokenInterpreterLanguage = bailCase.read(FCS1_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+            Optional<InterpreterLanguageRefData> fcs1SignInterpreterLanguage = bailCase.read(FCS1_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+
+            fcs1SpokenInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs1InterpreterSpokenLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs1InterpreterSpokenLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
+
+            fcs1SignInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs1InterpreterSignLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs1InterpreterSignLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
+        }
+    }
+
+    private void setFcs2InterpreterLanguageDetails(BailCase bailCase, Map<String, Object> fieldValues) {
+
+        Optional<List<String>> languageCategoriesOptional = bailCase.read(FCS2_INTERPRETER_LANGUAGE_CATEGORY);
+
+        if (languageCategoriesOptional.isPresent()) {
+            List<String> languageCategories = languageCategoriesOptional.get();
+
+            if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())
+                && languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs2InterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL + "\n" + SIGN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs2InterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs2InterpreterLanguageCategory", SIGN_INTERPRETER_LABEL);
+            }
+
+            Optional<InterpreterLanguageRefData> fcs2SpokenInterpreterLanguage = bailCase.read(FCS2_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+            Optional<InterpreterLanguageRefData> fcs2SignInterpreterLanguage = bailCase.read(FCS2_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+
+            fcs2SpokenInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs2InterpreterSpokenLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs2InterpreterSpokenLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
+
+            fcs2SignInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs2InterpreterSignLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs2InterpreterSignLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
+        }
+    }
+
+    private void setFcs3InterpreterLanguageDetails(BailCase bailCase, Map<String, Object> fieldValues) {
+
+        Optional<List<String>> languageCategoriesOptional = bailCase.read(FCS3_INTERPRETER_LANGUAGE_CATEGORY);
+
+        if (languageCategoriesOptional.isPresent()) {
+            List<String> languageCategories = languageCategoriesOptional.get();
+
+            if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())
+                && languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs3InterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL + "\n" + SIGN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs3InterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs3InterpreterLanguageCategory", SIGN_INTERPRETER_LABEL);
+            }
+
+            Optional<InterpreterLanguageRefData> fcs3SpokenInterpreterLanguage = bailCase.read(FCS3_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+            Optional<InterpreterLanguageRefData> fcs3SignInterpreterLanguage = bailCase.read(FCS3_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+
+            fcs3SpokenInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs3InterpreterSpokenLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs3InterpreterSpokenLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
+
+            fcs3SignInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs3InterpreterSignLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs3InterpreterSignLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
+        }
+    }
+
+    private void setFcs4InterpreterLanguageDetails(BailCase bailCase, Map<String, Object> fieldValues) {
+
+        Optional<List<String>> languageCategoriesOptional = bailCase.read(FCS4_INTERPRETER_LANGUAGE_CATEGORY);
+
+        if (languageCategoriesOptional.isPresent()) {
+            List<String> languageCategories = languageCategoriesOptional.get();
+
+            if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())
+                && languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs4InterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL + "\n" + SIGN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SPOKEN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs4InterpreterLanguageCategory", SPOKEN_INTERPRETER_LABEL);
+            } else if (languageCategories.contains(SIGN_LANGUAGE_INTERPRETER.getValue())) {
+                fieldValues.put("fcs4InterpreterLanguageCategory", SIGN_INTERPRETER_LABEL);
+            }
+
+            Optional<InterpreterLanguageRefData> fcs4SpokenInterpreterLanguage = bailCase.read(FCS4_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+            Optional<InterpreterLanguageRefData> fcs4SignInterpreterLanguage = bailCase.read(FCS4_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)
+                .filter(language -> language.getLanguageRefData() != null || language.getLanguageManualEntryDescription() != null);
+
+            fcs4SpokenInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs4InterpreterSpokenLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs4InterpreterSpokenLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
+
+            fcs4SignInterpreterLanguage.ifPresent(language -> {
+                if (language.getLanguageRefData() != null && language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs4InterpreterSignLanguage", language.getLanguageRefData().getValue().getLabel());
+                } else if (language.getLanguageManualEntry() != null && !language.getLanguageManualEntry().isEmpty()) {
+                    fieldValues.put("fcs4InterpreterSignLanguage", language.getLanguageManualEntryDescription());
+                }
+            });
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/BailCaseFieldDefinitionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/BailCaseFieldDefinitionTest.java
@@ -32,6 +32,6 @@ public class BailCaseFieldDefinitionTest {
 
     @Test
     public void should_fail_if_new_fields_added_in_class() {
-        assertEquals(146, values().length);
+        assertEquals(162, values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/BailSubmissionTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/BailSubmissionTemplateTest.java
@@ -5,12 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.BailCaseFieldDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.BailCaseFieldDefinition.APPEAL_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.BailCaseFieldDefinition.HOME_OFFICE_REFERENCE_NUMBER;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_COMPANY;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_FAMILY_NAME;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.BailCaseFieldDefinition.LEGAL_REP_NAME;
 
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,8 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.BailCase;
-import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.PriorApplication;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.*;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.AddressUk;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
@@ -376,6 +377,127 @@ public class BailSubmissionTemplateTest {
     }
 
     @Test
+    void should_set_interpreter_details_for_applicant_and_fcs_language_ref_data() {
+        dataSetUp();
+        InterpreterLanguageRefData spokenRefData = new InterpreterLanguageRefData(
+            new DynamicList(new Value("fre", "French"), Collections.emptyList()),
+            Collections.emptyList(),
+            null);
+
+        InterpreterLanguageRefData signRefData = new InterpreterLanguageRefData(
+            new DynamicList(new Value("bsl", "BSL"), Collections.emptyList()),
+            Collections.emptyList(),
+            null);
+
+        List<String> languageCategories = Arrays.asList("spokenLanguageInterpreter", "signLanguageInterpreter");
+
+        when(bailCase.read(FCS_INTERPRETER_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(bailCase.read(APPLICANT_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategories));
+        when(bailCase.read(FCS1_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategories));
+        when(bailCase.read(FCS2_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategories));
+        when(bailCase.read(FCS3_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategories));
+        when(bailCase.read(FCS4_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategories));
+        when(bailCase.read(APPLICANT_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        when(bailCase.read(APPLICANT_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        when(bailCase.read(FCS1_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        when(bailCase.read(FCS1_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        when(bailCase.read(FCS2_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        when(bailCase.read(FCS2_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        when(bailCase.read(FCS3_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        when(bailCase.read(FCS3_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        when(bailCase.read(FCS4_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        when(bailCase.read(FCS4_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        fieldValuesMap = bailSubmissionTemplate.mapFieldValues(caseDetails);
+
+        assertEquals("Spoken language interpreter\nSign language interpreter", fieldValuesMap.get("applicantInterpreterLanguageCategory"));
+        assertEquals("Spoken language interpreter\nSign language interpreter", fieldValuesMap.get("fcs1InterpreterLanguageCategory"));
+        assertEquals("Spoken language interpreter\nSign language interpreter", fieldValuesMap.get("fcs2InterpreterLanguageCategory"));
+        assertEquals("Spoken language interpreter\nSign language interpreter", fieldValuesMap.get("fcs3InterpreterLanguageCategory"));
+        assertEquals("Spoken language interpreter\nSign language interpreter", fieldValuesMap.get("fcs4InterpreterLanguageCategory"));
+        assertEquals(spokenRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("applicantInterpreterSpokenLanguage"));
+        assertEquals(signRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("applicantInterpreterSignLanguage"));
+        assertEquals(spokenRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("fcs1InterpreterSpokenLanguage"));
+        assertEquals(signRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("fcs1InterpreterSignLanguage"));
+        assertEquals(spokenRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("fcs2InterpreterSpokenLanguage"));
+        assertEquals(signRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("fcs2InterpreterSignLanguage"));
+        assertEquals(spokenRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("fcs3InterpreterSpokenLanguage"));
+        assertEquals(signRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("fcs3InterpreterSignLanguage"));
+        assertEquals(spokenRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("fcs4InterpreterSpokenLanguage"));
+        assertEquals(signRefData.getLanguageRefData().getValue().getLabel(), fieldValuesMap.get("fcs4InterpreterSignLanguage"));
+    }
+
+    @Test
+    void should_set_manual_interpreter_details_for_applicant_and_fcs_with_just_spoken_only() {
+        dataSetUp();
+        InterpreterLanguageRefData spokenRefData = new InterpreterLanguageRefData(
+            new DynamicList(new Value("", ""), Collections.emptyList()),
+            List.of("Yes"),
+            "Manual spoken");
+
+        List<String> languageCategoriesSpokenOnly = Arrays.asList("spokenLanguageInterpreter");
+
+        when(bailCase.read(FCS_INTERPRETER_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(bailCase.read(APPLICANT_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSpokenOnly));
+        when(bailCase.read(FCS1_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSpokenOnly));
+        when(bailCase.read(FCS2_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSpokenOnly));
+        when(bailCase.read(FCS3_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSpokenOnly));
+        when(bailCase.read(FCS4_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSpokenOnly));
+        when(bailCase.read(APPLICANT_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        when(bailCase.read(FCS1_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        when(bailCase.read(FCS2_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        when(bailCase.read(FCS3_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        when(bailCase.read(FCS4_INTERPRETER_SPOKEN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(spokenRefData));
+        fieldValuesMap = bailSubmissionTemplate.mapFieldValues(caseDetails);
+
+        assertEquals("Spoken language interpreter", fieldValuesMap.get("applicantInterpreterLanguageCategory"));
+        assertEquals("Spoken language interpreter", fieldValuesMap.get("fcs1InterpreterLanguageCategory"));
+        assertEquals("Spoken language interpreter", fieldValuesMap.get("fcs2InterpreterLanguageCategory"));
+        assertEquals("Spoken language interpreter", fieldValuesMap.get("fcs3InterpreterLanguageCategory"));
+        assertEquals("Spoken language interpreter", fieldValuesMap.get("fcs4InterpreterLanguageCategory"));
+        assertEquals(spokenRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("applicantInterpreterSpokenLanguage"));
+        assertEquals(spokenRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("fcs1InterpreterSpokenLanguage"));
+        assertEquals(spokenRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("fcs2InterpreterSpokenLanguage"));
+        assertEquals(spokenRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("fcs3InterpreterSpokenLanguage"));
+        assertEquals(spokenRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("fcs4InterpreterSpokenLanguage"));
+    }
+
+    @Test
+    void should_set_manual_interpreter_details_for_applicant_and_fcs_with_just_sign_only() {
+        dataSetUp();
+
+        InterpreterLanguageRefData signRefData = new InterpreterLanguageRefData(
+            new DynamicList(new Value("", ""), Collections.emptyList()),
+            List.of("Yes"),
+            "Manual sign");
+
+        List<String> languageCategoriesSignOnly = Arrays.asList("signLanguageInterpreter");
+
+        when(bailCase.read(FCS_INTERPRETER_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(bailCase.read(APPLICANT_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSignOnly));
+        when(bailCase.read(FCS1_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSignOnly));
+        when(bailCase.read(FCS2_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSignOnly));
+        when(bailCase.read(FCS3_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSignOnly));
+        when(bailCase.read(FCS4_INTERPRETER_LANGUAGE_CATEGORY)).thenReturn(Optional.of(languageCategoriesSignOnly));
+        when(bailCase.read(APPLICANT_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        when(bailCase.read(FCS1_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        when(bailCase.read(FCS2_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        when(bailCase.read(FCS3_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        when(bailCase.read(FCS4_INTERPRETER_SIGN_LANGUAGE, InterpreterLanguageRefData.class)).thenReturn(Optional.of(signRefData));
+        fieldValuesMap = bailSubmissionTemplate.mapFieldValues(caseDetails);
+
+        assertEquals("Sign language interpreter", fieldValuesMap.get("applicantInterpreterLanguageCategory"));
+        assertEquals("Sign language interpreter", fieldValuesMap.get("fcs1InterpreterLanguageCategory"));
+        assertEquals("Sign language interpreter", fieldValuesMap.get("fcs2InterpreterLanguageCategory"));
+        assertEquals("Sign language interpreter", fieldValuesMap.get("fcs3InterpreterLanguageCategory"));
+        assertEquals("Sign language interpreter", fieldValuesMap.get("fcs4InterpreterLanguageCategory"));
+        assertEquals(signRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("applicantInterpreterSignLanguage"));
+        assertEquals(signRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("fcs1InterpreterSignLanguage"));
+        assertEquals(signRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("fcs2InterpreterSignLanguage"));
+        assertEquals(signRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("fcs3InterpreterSignLanguage"));
+        assertEquals(signRefData.getLanguageManualEntryDescription(), fieldValuesMap.get("fcs4InterpreterSignLanguage"));
+    }
+
+    @Test
     void should_not_show_previous_application_details_if_prior_applications_dont_exist() {
         dataSetUp();
         when(bailCase.read(PRIOR_APPLICATIONS, PriorApplication.class)).thenReturn(Optional.of(priorApplication));
@@ -531,7 +653,6 @@ public class BailSubmissionTemplateTest {
         when(bailCase.read(TRANSFER_BAIL_MANAGEMENT_YES_OR_NO, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(bailCase.read(GROUNDS_FOR_BAIL_PROVIDE_EVIDENCE_OPTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
         when(bailCase.read(INTERPRETER_YES_NO, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
-        when(bailCase.read(INTERPRETER_LANGUAGES)).thenReturn(Optional.of(interpreterLanguages));
         when(bailCase.read(APPLICANT_DISABILITY1, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
         when(bailCase.read(VIDEO_HEARING1, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
 


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-8119

### Change description ###
- Applicant and FCS interpreter requirements added to the bail application document upon submission
- Unit tests added to cover spoken+sign languages, language ref data + manual entry, and applicant+fcs interpreter requirements.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
