### PR TITLE
RIA-TASK - Fix for missing document tags when end appeal for EJP non DE case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
@@ -76,6 +76,8 @@ public enum DocumentTag {
     INTERNAL_HO_CHANGE_DIRECTION_DUE_DATE_LETTER("internalHoChangeDirectionDueDateLetter", CaseType.ASYLUM),
     INTERNAL_REINSTATE_APPEAL_LETTER("internalReinstateAppealLetter", CaseType.ASYLUM),
     INTERNAL_ADJOURN_HEARING_WITHOUT_DATE("internalAdjournHearingWithoutDate", CaseType.ASYLUM),
+    UPPER_TRIBUNAL_TRANSFER_ORDER_DOCUMENT("upperTribunalTransferOrderDocument", CaseType.ASYLUM),
+    IAUT_2_FORM("iAUT2Form", CaseType.ASYLUM),
     BAIL_SUBMISSION("bailSubmission", CaseType.BAIL),
     BAIL_EVIDENCE("uploadTheBailEvidenceDocs", CaseType.BAIL),
     BAIL_DECISION_UNSIGNED("bailDecisionUnsigned", CaseType.BAIL),

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseType;
 
 class DocumentTagTest {
 
@@ -77,10 +78,12 @@ class DocumentTagTest {
         assertEquals("internalHoChangeDirectionDueDateLetter", DocumentTag.INTERNAL_HO_CHANGE_DIRECTION_DUE_DATE_LETTER.toString());
         assertEquals("internalReinstateAppealLetter", DocumentTag.INTERNAL_REINSTATE_APPEAL_LETTER.toString());
         assertEquals("internalAdjournHearingWithoutDate", DocumentTag.INTERNAL_ADJOURN_HEARING_WITHOUT_DATE.toString());
+        assertEquals("upperTribunalTransferOrderDocument", DocumentTag.UPPER_TRIBUNAL_TRANSFER_ORDER_DOCUMENT.toString());
+        assertEquals("iAUT2Form", DocumentTag.IAUT_2_FORM.toString());
     }
 
     @Test
     void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(78, DocumentTag.values().length);
+        assertEquals(80, DocumentTag.values().length);
     }
 }


### PR DESCRIPTION
Fix for missing document tags when end appeal for EJP non DE case

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
