### PR TITLE
DIAC-401 Update chart version

### DIFF
--- a/charts/ia-case-documents-api/Chart.yaml
+++ b/charts/ia-case-documents-api/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
     email: ImmigrationandAsylum@HMCTS.NET
 dependencies:
   - name: java
-    version: 5.2.0
+    version: 5.2.1
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/

--- a/charts/ia-case-documents-api/Chart.yaml
+++ b/charts/ia-case-documents-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: ia-case-documents-api
 home: https://github.com/hmcts/ia-case-documents-api
-version: 0.0.39
+version: 0.0.40
 description: Immigration & Asylum Case Documents Service
 maintainers:
   - name: HMCTS Immigration & Asylum Team


### PR DESCRIPTION
Bump charts version

Some of the template versions/names were straightened out in the 5.2.1 release. We're hoping this will help fix https://tools.hmcts.net/jira/browse/DIAC-401