### PR TITLE
RIA-8337 Internal end appeal letter generation and bundling with attachment

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-8337-internal-non-detained-end-appeal-letter.json
+++ b/src/functionalTest/resources/scenarios/RIA-8337-internal-non-detained-end-appeal-letter.json
@@ -1,0 +1,61 @@
+{
+  "description": "RIA-8337 Internal non-detained end appeal letter + attachment bundle",
+  "request": {
+    "uri": "/asylum/ccdAboutToSubmit",
+    "credentials": "AdminOfficer",
+    "input": {
+      "eventId": "endAppeal",
+      "state": "appealSubmitted",
+      "caseData": {
+        "template": "minimal-internal-appeal-submitted.json",
+        "replacements": {
+          "appellantInDetention": "No",
+          "isAdmin": "Yes",
+          "appellantAddress": {
+            "County": "",
+            "Country": "United Kingdom",
+            "PostCode": "NE21JX",
+            "PostTown": "Example Town",
+            "AddressLine1": "5",
+            "AddressLine2": "Example Street"
+          },
+          "letterBundleDocuments": []
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-internal-appeal-submitted.json",
+      "replacements": {
+        "appellantInDetention": "No",
+        "isAdmin": "Yes",
+        "appellantAddress": {
+          "County": "",
+          "Country": "United Kingdom",
+          "PostCode": "NE21JX",
+          "PostTown": "Example Town",
+          "AddressLine1": "5",
+          "AddressLine2": "Example Street"
+        },
+        "letterBundleDocuments": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/",
+                "document_binary_url": "$/http.+\/documents/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/binary/",
+                "document_filename": "PA 12345 2019-Awan-internal-end-appeal-letter-with-attachment.PDF"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "internalEndAppealLetterBundle"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/AsylumCaseDefinition.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/AsylumCaseDefinition.java
@@ -609,7 +609,15 @@ public enum AsylumCaseDefinition {
         "reinstatedDecisionMaker", new TypeReference<String>(){}),
 
     ADJOURN_HEARING_WITHOUT_DATE_REASONS(
-        "adjournHearingWithoutDateReasons", new TypeReference<String>() {});
+        "adjournHearingWithoutDateReasons", new TypeReference<String>() {}),
+
+    // Used to store generated letter notification docs which will be stitched together
+    LETTER_NOTIFICATION_DOCUMENTS(
+        "letterNotificationDocuments", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){}),
+
+    // Used to store bundled documents (letter + attachment) to be sent to GovNotify
+    LETTER_BUNDLE_DOCUMENTS(
+        "letterBundleDocuments", new TypeReference<List<IdValue<DocumentWithMetadata>>>(){});
 
     private final String value;
     private final TypeReference typeReference;

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTag.java
@@ -81,6 +81,8 @@ public enum DocumentTag {
     INTERNAL_ADJOURN_HEARING_WITHOUT_DATE("internalAdjournHearingWithoutDate", CaseType.ASYLUM),
     UPPER_TRIBUNAL_TRANSFER_ORDER_DOCUMENT("upperTribunalTransferOrderDocument", CaseType.ASYLUM),
     IAUT_2_FORM("iAUT2Form", CaseType.ASYLUM),
+    INTERNAL_END_APPEAL_LETTER("internalEndAppealLetter", CaseType.ASYLUM),
+    INTERNAL_END_APPEAL_LETTER_BUNDLE("internalEndAppealLetterBundle", CaseType.ASYLUM),
     BAIL_SUBMISSION("bailSubmission", CaseType.BAIL),
     BAIL_EVIDENCE("uploadTheBailEvidenceDocs", CaseType.BAIL),
     BAIL_DECISION_UNSIGNED("bailDecisionUnsigned", CaseType.BAIL),

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/EndAppealNoticeCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/EndAppealNoticeCreator.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit;
 
 import static java.util.Objects.requireNonNull;
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.JOURNEY_TYPE;
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.TRIBUNAL_DOCUMENTS;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.JourneyType.AIP;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.*;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -78,6 +78,15 @@ public class EndAppealNoticeCreator implements PreSubmitCallbackHandler<AsylumCa
             TRIBUNAL_DOCUMENTS,
             DocumentTag.END_APPEAL
         );
+
+        if (isInternalNonDetainedCase(asylumCase)) {
+            documentHandler.addWithMetadataWithoutReplacingExistingDocuments(
+                asylumCase,
+                endAppealNotice,
+                LETTER_NOTIFICATION_DOCUMENTS,
+                DocumentTag.INTERNAL_END_APPEAL_LETTER
+            );
+        }
 
         return new PreSubmitCallbackResponse<>(asylumCase);
     }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalEndAppealLetterGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalEndAppealLetterGenerator.java
@@ -1,0 +1,72 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit.letter;
+
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.LETTER_NOTIFICATION_DOCUMENTS;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.*;
+
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+
+@Component
+public class InternalEndAppealLetterGenerator implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final DocumentCreator<AsylumCase> documentCreator;
+    private final DocumentHandler documentHandler;
+
+    public InternalEndAppealLetterGenerator(
+        @Qualifier("internalEndAppealLetter") DocumentCreator<AsylumCase> documentCreator,
+        DocumentHandler documentHandler
+    ) {
+        this.documentCreator = documentCreator;
+        this.documentHandler = documentHandler;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        Objects.requireNonNull(callbackStage, "callbackStage must not be null");
+        Objects.requireNonNull(callback, "callback must not be null");
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && callback.getEvent() == END_APPEAL
+               && isInternalCase(asylumCase)
+               && !isAppellantInDetention(asylumCase);
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        Document internalEndAppealLetter = documentCreator.create(caseDetails);
+
+        documentHandler.addWithMetadataWithoutReplacingExistingDocuments(
+            asylumCase,
+            internalEndAppealLetter,
+            LETTER_NOTIFICATION_DOCUMENTS,
+            DocumentTag.INTERNAL_END_APPEAL_LETTER
+        );
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalEndAppealLetterWithAttachmentBundleHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalEndAppealLetterWithAttachmentBundleHandler.java
@@ -1,0 +1,115 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit.letter;
+
+import static java.util.Objects.requireNonNull;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event.END_APPEAL;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.isAppellantInDetention;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.isInternalCase;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.DispatchPriority;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentBundler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.FileNameQualifier;
+
+@Component
+public class InternalEndAppealLetterWithAttachmentBundleHandler implements PreSubmitCallbackHandler<AsylumCase> {
+
+    private final String fileExtension;
+    private final String fileName;
+    private final boolean isEmStitchingEnabled;
+    private final FileNameQualifier<AsylumCase> fileNameQualifier;
+    private final DocumentBundler documentBundler;
+    private final DocumentHandler documentHandler;
+
+    public InternalEndAppealLetterWithAttachmentBundleHandler(
+        @Value("${internalEndAppealLetterWithAttachment.fileExtension}") String fileExtension,
+        @Value("${internalEndAppealLetterWithAttachment.fileName}") String fileName,
+        @Value("${featureFlag.isEmStitchingEnabled}") boolean isEmStitchingEnabled,
+        FileNameQualifier<AsylumCase> fileNameQualifier,
+        DocumentBundler documentBundler,
+        DocumentHandler documentHandler
+    ) {
+        this.fileExtension = fileExtension;
+        this.fileName = fileName;
+        this.isEmStitchingEnabled = isEmStitchingEnabled;
+        this.fileNameQualifier = fileNameQualifier;
+        this.documentBundler = documentBundler;
+        this.documentHandler = documentHandler;
+    }
+
+    public boolean canHandle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        requireNonNull(callbackStage, "callbackStage must not be null");
+        requireNonNull(callback, "callback must not be null");
+
+        AsylumCase asylumCase = callback.getCaseDetails().getCaseData();
+
+        return callbackStage == PreSubmitCallbackStage.ABOUT_TO_SUBMIT
+               && callback.getEvent() == END_APPEAL
+               && isInternalCase(asylumCase)
+               && !isAppellantInDetention(asylumCase)
+               && isEmStitchingEnabled;
+    }
+
+    @Override
+    public DispatchPriority getDispatchPriority() {
+        return DispatchPriority.LATE;
+    }
+
+    public PreSubmitCallbackResponse<AsylumCase> handle(
+        PreSubmitCallbackStage callbackStage,
+        Callback<AsylumCase> callback
+    ) {
+        if (!canHandle(callbackStage, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        final CaseDetails<AsylumCase> caseDetails = callback.getCaseDetails();
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        final String qualifiedDocumentFileName = fileNameQualifier.get(fileName + "." + fileExtension, caseDetails);
+
+        Optional<List<IdValue<DocumentWithMetadata>>> maybeLetterNotificationDocuments = asylumCase.read(LETTER_NOTIFICATION_DOCUMENTS);
+        List<DocumentWithMetadata> bundleDocuments = maybeLetterNotificationDocuments
+            .orElse(Collections.emptyList())
+            .stream()
+            .map(IdValue::getValue)
+            .filter(document -> document.getTag() == DocumentTag.INTERNAL_END_APPEAL_LETTER)
+            .collect(Collectors.toList());
+
+        Document internalEndAppealLetterBundle = documentBundler.bundleWithoutContentsOrCoverSheets(
+            bundleDocuments,
+            "Letter bundle documents",
+            qualifiedDocumentFileName
+        );
+
+        documentHandler.addWithMetadataWithoutReplacingExistingDocuments(
+            asylumCase,
+            internalEndAppealLetterBundle,
+            LETTER_BUNDLE_DOCUMENTS,
+            DocumentTag.INTERNAL_END_APPEAL_LETTER_BUNDLE
+        );
+
+        asylumCase.clear(LETTER_NOTIFICATION_DOCUMENTS);
+
+        return new PreSubmitCallbackResponse<>(asylumCase);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrder.java
@@ -222,8 +222,14 @@ public class BundleOrder implements Comparator<DocumentWithMetadata> {
             case UPDATED_FINAL_DECISION_AND_REASONS_PDF:
                 log.warn("UPDATED_FINAL_DECISION_AND_REASONS_PDF tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
                 return 74;
-            case NONE:
+            case INTERNAL_END_APPEAL_LETTER:
+                log.warn("INTERNAL_END_APPEAL_LETTER tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
                 return 75;
+            case INTERNAL_END_APPEAL_LETTER_BUNDLE:
+                log.warn("INTERNAL_END_APPEAL_LETTER_BUNDLE tag should not be checked for bundle ordering, document desc: {}", document.getDescription());
+                return 76;
+            case NONE:
+                return 77;
             default:
                 throw new IllegalStateException("document has unknown tag: " + document.getTag() + ", description: " + document.getDescription());
         }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/DocumentBundler.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/DocumentBundler.java
@@ -11,4 +11,10 @@ public interface DocumentBundler {
         String bundleTitle,
         String bundleFilename
     );
+
+    Document bundleWithoutContentsOrCoverSheets(
+        List<DocumentWithMetadata> documents,
+        String bundleTitle,
+        String bundleFilename
+    );
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalEndAppealLetterTemplate.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalEndAppealLetterTemplate.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.AsylumCaseUtils.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.DocumentTemplate;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+
+@Component
+public class InternalEndAppealLetterTemplate implements DocumentTemplate<AsylumCase> {
+
+    private final String templateName;
+    private final CustomerServicesProvider customerServicesProvider;
+    private static final DateTimeFormatter DOCUMENT_DATE_FORMAT = DateTimeFormatter.ofPattern("d MMMM yyyy");
+
+    public InternalEndAppealLetterTemplate(
+        @Value("${internalEndAppealLetter.templateName}") String templateName,
+        CustomerServicesProvider customerServicesProvider) {
+        this.templateName = templateName;
+        this.customerServicesProvider = customerServicesProvider;
+    }
+
+    @Override
+    public String getName() {
+        return templateName;
+    }
+
+    public Map<String, Object> mapFieldValues(
+        CaseDetails<AsylumCase> caseDetails
+    ) {
+        final AsylumCase asylumCase = caseDetails.getCaseData();
+
+        final Map<String, Object> fieldValues = new HashMap<>();
+
+        List<String> appellantAddress = getAppellantAddressAsList(asylumCase);
+
+        fieldValues.putAll(getAppellantPersonalisation(asylumCase));
+        fieldValues.put("decisionMaker", asylumCase.read(END_APPEAL_APPROVER_TYPE, String.class).orElse(""));
+        fieldValues.put("endAppealDate", formatDateForRendering(asylumCase.read(END_APPEAL_DATE, String.class).orElse(""), DOCUMENT_DATE_FORMAT));
+        fieldValues.put("customerServicesTelephone", customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase));
+        fieldValues.put("customerServicesEmail", customerServicesProvider.getInternalCustomerServicesEmail(asylumCase));
+        fieldValues.put("dateLetterSent", formatDateForRendering(LocalDate.now().toString(), DOCUMENT_DATE_FORMAT));
+
+        for (int i = 0; i < appellantAddress.size(); i++) {
+            fieldValues.put("address_line_" + (i + 1), appellantAddress.get(i));
+        }
+        return fieldValues;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/utils/AsylumCaseUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/utils/AsylumCaseUtils.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils;
 import static java.util.Objects.requireNonNull;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumAppealType.*;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.JourneyType.AIP;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo.YES;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.utils.DateUtils.formatDateForNotificationAttachmentDocument;
@@ -12,14 +13,13 @@ import com.google.common.collect.ImmutableMap;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.RequiredFieldMissingException;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.AddressUk;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.JourneyType;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.DirectionFinder;
 
@@ -48,6 +48,10 @@ public class AsylumCaseUtils {
 
     public static boolean isInternalCase(AsylumCase asylumCase) {
         return asylumCase.read(IS_ADMIN, YesOrNo.class).map(isAdmin -> YES == isAdmin).orElse(false);
+    }
+
+    public static boolean isInternalNonDetainedCase(AsylumCase asylumCase) {
+        return isInternalCase(asylumCase) && !isAppellantInDetention(asylumCase);
     }
 
     public static List<IdValue<Direction>> getCaseDirections(AsylumCase asylumCase) {
@@ -206,4 +210,26 @@ public class AsylumCaseUtils {
                 .build();
     }
 
+    public static List<String> getAppellantAddressAsList(final AsylumCase asylumCase) {
+        AddressUk address = asylumCase
+            .read(AsylumCaseDefinition.APPELLANT_ADDRESS, AddressUk.class)
+            .orElseThrow(() -> new IllegalStateException("appellantAddress is not present"));
+
+        List<String> appellantAddressAsList = new ArrayList<>();
+
+        appellantAddressAsList.add(address.getAddressLine1().orElseThrow(() -> new IllegalStateException("appellantAddress line 1 is not present")));
+        String addressLine2 = address.getAddressLine2().orElse(null);
+        String addressLine3 = address.getAddressLine3().orElse(null);
+
+        if (addressLine2 != null) {
+            appellantAddressAsList.add(addressLine2);
+        }
+        if (addressLine3 != null) {
+            appellantAddressAsList.add(addressLine3);
+        }
+        appellantAddressAsList.add(address.getPostTown().orElseThrow(() -> new IllegalStateException("appellantAddress postTown is not present")));
+        appellantAddressAsList.add(address.getPostCode().orElseThrow(() -> new IllegalStateException("appellantAddress postCode is not present")));
+
+        return appellantAddressAsList;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/config/DocumentCreatorConfiguration.java
@@ -1592,4 +1592,25 @@ public class DocumentCreatorConfiguration {
             documentUploader
         );
     }
+
+    @Bean("internalEndAppealLetter")
+    public DocumentCreator<AsylumCase> getinternalEndAppealLetterDocumentCreator(
+        @Value("${internalEndAppealLetter.contentType}") String contentType,
+        @Value("${internalEndAppealLetter.fileExtension}") String fileExtension,
+        @Value("${internalEndAppealLetter.fileName}") String fileName,
+        AsylumCaseFileNameQualifier fileNameQualifier,
+        InternalEndAppealLetterTemplate documentTemplate,
+        DocumentGenerator documentGenerator,
+        DocumentUploader documentUploader
+    ) {
+        return new DocumentCreator<>(
+            contentType,
+            fileExtension,
+            fileName,
+            fileNameQualifier,
+            documentTemplate,
+            documentGenerator,
+            documentUploader
+        );
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/enties/em/Bundle.java
+++ b/src/main/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/enties/em/Bundle.java
@@ -55,6 +55,26 @@ public class Bundle implements CaseData {
         String description,
         String eligibleForStitching,
         List<IdValue<BundleDocument>> documents,
+        YesOrNo hasCoversheets,
+        YesOrNo hasTableOfContents,
+        String filename
+    ) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.eligibleForStitching = eligibleForStitching;
+        this.documents = documents;
+        this.hasCoversheets = hasCoversheets;
+        this.hasTableOfContents = hasTableOfContents;
+        this.filename = filename;
+    }
+
+    public Bundle(
+        String id,
+        String title,
+        String description,
+        String eligibleForStitching,
+        List<IdValue<BundleDocument>> documents,
         Optional<String> stitchStatus,
         Optional<Document> stitchedDocument,
         YesOrNo hasCoversheets,
@@ -71,7 +91,6 @@ public class Bundle implements CaseData {
         this.hasCoversheets = hasCoversheets;
         this.hasTableOfContents = hasTableOfContents;
         this.filename = filename;
-
     }
 
     public String getId() {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -452,6 +452,14 @@ internalDetainedAdjournHearingWithoutDateLetter.fileExtension: PDF
 internalDetainedAdjournHearingWithoutDateLetter.fileName: "internal-detained-adjourn-hearing-without-date-letter"
 internalDetainedAdjournHearingWithoutDateLetter.templateName: ${INTERNAL_ADJOURN_HEARING_WITHOUT_DATE_LETTER_TEMPLATE:TB-IAC-LET-ENG-00040.docx}
 
+internalEndAppealLetter.contentType:  application/pdf
+internalEndAppealLetter.fileExtension: PDF
+internalEndAppealLetter.fileName: "internal-end-appeal-letter"
+internalEndAppealLetter.templateName: ${INTERNAL_END_APPEAL_LETTER_TEMPLATE:TB-IAC-LET-ENG-Internal-End-Appeal.docx}
+
+internalEndAppealLetterWithAttachment.fileExtension: PDF
+internalEndAppealLetterWithAttachment.fileName: "internal-end-appeal-letter-with-attachment"
+
 bailNoticeOfHearing.contentType: application/pdf
 bailNoticeOfHearing.fileExtension: PDF
 bailNoticeOfHearing.fileName: "hearing-notice"

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/entities/DocumentTagTest.java
@@ -82,12 +82,14 @@ class DocumentTagTest {
         assertEquals("internalReinstateAppealLetter", DocumentTag.INTERNAL_REINSTATE_APPEAL_LETTER.toString());
         assertEquals("internalAdjournHearingWithoutDate", DocumentTag.INTERNAL_ADJOURN_HEARING_WITHOUT_DATE.toString());
         assertEquals("upperTribunalTransferOrderDocument", DocumentTag.UPPER_TRIBUNAL_TRANSFER_ORDER_DOCUMENT.toString());
+        assertEquals("internalEndAppealLetter", DocumentTag.INTERNAL_END_APPEAL_LETTER.toString());
+        assertEquals("internalEndAppealLetterBundle", DocumentTag.INTERNAL_END_APPEAL_LETTER_BUNDLE.toString());
         assertEquals("iAUT2Form", DocumentTag.IAUT_2_FORM.toString());
         assertEquals("", DocumentTag.NONE.toString());
     }
 
     @Test
     public void if_this_test_fails_it_is_because_it_needs_updating_with_your_changes() {
-        assertEquals(84, DocumentTag.values().length);
+        assertEquals(86, DocumentTag.values().length);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/EndAppealNoticeCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/EndAppealNoticeCreatorTest.java
@@ -3,8 +3,9 @@ package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.JOURNEY_TYPE;
-import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.TRIBUNAL_DOCUMENTS;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +25,7 @@ import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSu
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.JourneyType;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
 
@@ -39,10 +41,6 @@ public class EndAppealNoticeCreatorTest {
     @Mock private CaseDetails<AsylumCase> caseDetails;
     @Mock private AsylumCase asylumCase;
     @Mock private Document uploadedDocument;
-    @Mock private DocumentWithMetadata documentWithMetadata;
-    @Mock private List<IdValue<DocumentWithMetadata>> existingHearingDocuments;
-    @Mock private List<IdValue<DocumentWithMetadata>> allHearingDocuments;
-
     private EndAppealNoticeCreator endAppealNoticeCreator;
 
     @BeforeEach
@@ -98,6 +96,31 @@ public class EndAppealNoticeCreatorTest {
         verify(endAppealNoticeDocumentCreator, times(0)).create(caseDetails);
         verify(endAppealAppellantNoticeDocumentCreator, times(1)).create(caseDetails);
         verify(documentHandler, times(1)).addWithMetadataWithoutReplacingExistingDocuments(asylumCase, uploadedDocument, TRIBUNAL_DOCUMENTS, DocumentTag.END_APPEAL);
+    }
+
+    @Test
+    public void should_create_end_appeal_notice_pdf_and_append_to_letter_notifications_documents_for_internal_non_detained() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.END_APPEAL);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(NO));
+
+        JourneyType journeyType = JourneyType.REP;
+        when(asylumCase.read(JOURNEY_TYPE, JourneyType.class))
+            .thenReturn(Optional.of(journeyType));
+
+        when(endAppealNoticeDocumentCreator.create(caseDetails)).thenReturn(uploadedDocument);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            endAppealNoticeCreator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(endAppealAppellantNoticeDocumentCreator, times(0)).create(caseDetails);
+        verify(endAppealNoticeDocumentCreator, times(1)).create(caseDetails);
+        verify(documentHandler, times(1)).addWithMetadataWithoutReplacingExistingDocuments(asylumCase, uploadedDocument, LETTER_NOTIFICATION_DOCUMENTS, DocumentTag.INTERNAL_END_APPEAL_LETTER);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalEndAppealLetterGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalEndAppealLetterGeneratorTest.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit.letter;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentCreator;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
+@MockitoSettings(strictness = Strictness.LENIENT)
+class InternalEndAppealLetterGeneratorTest {
+    @Mock
+    private DocumentCreator<AsylumCase> documentCreator;
+    @Mock
+    private DocumentHandler documentHandler;
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private Document document;
+
+    private InternalEndAppealLetterGenerator internalEndAppealLetterGenerator;
+
+    @BeforeEach
+    void setUp() {
+        internalEndAppealLetterGenerator =
+            new InternalEndAppealLetterGenerator(documentCreator, documentHandler);
+    }
+
+    @Test
+    void should_create_internal_end_appeal_letter_pdf_and_append_to_letter_notifications_documents() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.END_APPEAL);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getCaseDetails().getCaseData().read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        when(documentCreator.create(caseDetails)).thenReturn(document);
+
+        PreSubmitCallbackResponse<AsylumCase> callbackResponse =
+            internalEndAppealLetterGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(callbackResponse);
+        assertEquals(asylumCase, callbackResponse.getData());
+
+        verify(documentHandler, times(1)).addWithMetadataWithoutReplacingExistingDocuments(
+            asylumCase, document,
+            LETTER_NOTIFICATION_DOCUMENTS,
+            DocumentTag.INTERNAL_END_APPEAL_LETTER
+        );
+    }
+
+    @Test
+    void handling_should_throw_if_cannot_actually_handle() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getEvent()).thenReturn(Event.END_APPEAL_AUTOMATICALLY);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(callback.getCaseDetails().getCaseData().read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.YES));
+        when(callback.getCaseDetails().getCaseData().read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+        assertThatThrownBy(() -> internalEndAppealLetterGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+        assertThatThrownBy(() -> internalEndAppealLetterGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void it_cannot_handle_callback_if_is_admin_is_missing() {
+
+        for (Event event : Event.values()) {
+
+            when(callback.getEvent()).thenReturn(event);
+            when(callback.getCaseDetails()).thenReturn(caseDetails);
+            when(caseDetails.getCaseData()).thenReturn(asylumCase);
+            when(callback.getCaseDetails().getCaseData().read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(YesOrNo.NO));
+
+            for (PreSubmitCallbackStage callbackStage : PreSubmitCallbackStage.values()) {
+                boolean canHandle = internalEndAppealLetterGenerator.canHandle(callbackStage, callback);
+                assertFalse(canHandle);
+            }
+            reset(callback);
+        }
+    }
+
+    @Test
+    void should_not_allow_null_arguments() {
+
+        assertThatThrownBy(() -> internalEndAppealLetterGenerator.canHandle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> internalEndAppealLetterGenerator.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> internalEndAppealLetterGenerator.handle(null, callback))
+            .hasMessage("callbackStage must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+
+        assertThatThrownBy(() -> internalEndAppealLetterGenerator.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, null))
+            .hasMessage("callback must not be null")
+            .isExactlyInstanceOf(NullPointerException.class);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalEndAppealLetterWithAttachmentBundleHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/letter/InternalEndAppealLetterWithAttachmentBundleHandlerTest.java
@@ -1,0 +1,209 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.handlers.presubmit.letter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.DispatchPriority.LATE;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_START;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo.NO;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo.YES;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.Value;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentTag;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.DocumentWithMetadata;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.Event;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.Callback;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.callback.PreSubmitCallbackStage;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentBundler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.DocumentHandler;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.service.FileNameQualifier;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.SystemDateProvider;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class InternalEndAppealLetterWithAttachmentBundleHandlerTest {
+
+    private InternalEndAppealLetterWithAttachmentBundleHandler internalEndAppealLetterWithAttachmentBundleHandler;
+    @Mock
+    private Callback<AsylumCase> callback;
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private FileNameQualifier<AsylumCase> fileNameQualifier;
+    @Mock
+    private DocumentBundler documentBundler;
+    @Mock
+    private DocumentHandler documentHandler;
+    @Mock
+    private Document bundleDocument;
+    private String fileExtension = "PDF";
+    private String fileName = "some-file-name";
+
+    @BeforeEach
+    public void setUp() {
+
+        internalEndAppealLetterWithAttachmentBundleHandler =
+            new InternalEndAppealLetterWithAttachmentBundleHandler(
+                fileExtension,
+                fileName,
+                true,
+                fileNameQualifier,
+                documentBundler,
+                documentHandler);
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateDifferentEventScenarios")
+    public void it_can_handle_callback(InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario scenario) {
+        when(callback.getEvent()).thenReturn(scenario.getEvent());
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(NO));
+
+        boolean canHandle = internalEndAppealLetterWithAttachmentBundleHandler.canHandle(scenario.callbackStage, callback);
+
+        assertEquals(canHandle, scenario.isExpected());
+    }
+
+    private static List<InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario> generateDifferentEventScenarios() {
+        return InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario.builder();
+    }
+
+    @Value
+    static class TestScenario {
+        Event event;
+        PreSubmitCallbackStage callbackStage;
+        boolean expected;
+
+        public static List<InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario> builder() {
+            List<InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario> testScenarios = new ArrayList<>();
+            for (Event e : Event.values()) {
+                if (e.equals(Event.END_APPEAL)) {
+                    testScenarios.add(new InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario(e, ABOUT_TO_START, false));
+                    testScenarios.add(new InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario(e, ABOUT_TO_SUBMIT, true));
+                } else {
+                    testScenarios.add(new InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario(e, ABOUT_TO_START, false));
+                    testScenarios.add(new InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario(e, ABOUT_TO_SUBMIT, false));
+                    testScenarios.add(new InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario(e, ABOUT_TO_START, false));
+                    testScenarios.add(new InternalEndAppealLetterWithAttachmentBundleHandlerTest.TestScenario(e, ABOUT_TO_SUBMIT, false));
+                }
+            }
+            return testScenarios;
+        }
+    }
+
+    @Test
+    public void it_should_not_handle_callback_when_stitching_flag_is_false() {
+        when(callback.getEvent()).thenReturn(Event.END_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(NO));
+
+        internalEndAppealLetterWithAttachmentBundleHandler =
+            new InternalEndAppealLetterWithAttachmentBundleHandler(
+                fileExtension,
+                fileName,
+                false,
+                fileNameQualifier,
+                documentBundler,
+                documentHandler);
+
+        boolean canHandle = internalEndAppealLetterWithAttachmentBundleHandler.canHandle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertFalse(canHandle);
+    }
+
+    @Test
+    void should_read_and_bundle_letter_notification_documents() {
+        when(callback.getEvent()).thenReturn(Event.END_APPEAL);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(NO));
+        when(fileNameQualifier.get(anyString(), eq(caseDetails))).thenReturn("filename");
+
+        IdValue<DocumentWithMetadata> doc1 = new IdValue<>("1", createDocumentWithMetadata());
+        IdValue<DocumentWithMetadata> doc2 = new IdValue<>("2", createDocumentWithMetadata());
+
+        when(asylumCase.read(LETTER_NOTIFICATION_DOCUMENTS)).thenReturn(Optional.of(List.of(doc1, doc2)));
+        when(documentBundler.bundleWithoutContentsOrCoverSheets(
+            anyList(),
+            eq("Letter bundle documents"),
+            eq("filename")
+        )).thenReturn(bundleDocument);
+
+        PreSubmitCallbackResponse<AsylumCase> response = internalEndAppealLetterWithAttachmentBundleHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback);
+
+        assertNotNull(response);
+        assertEquals(asylumCase, response.getData());
+        verify(documentHandler, times(1)).addWithMetadataWithoutReplacingExistingDocuments(
+            asylumCase, bundleDocument, LETTER_BUNDLE_DOCUMENTS, DocumentTag.INTERNAL_END_APPEAL_LETTER_BUNDLE
+        );
+        verify(asylumCase, times(1)).clear(LETTER_NOTIFICATION_DOCUMENTS);
+    }
+
+    @Test
+    void set_to_late_dispatch() {
+        assertThat(internalEndAppealLetterWithAttachmentBundleHandler.getDispatchPriority()).isEqualTo(LATE);
+    }
+
+    @Test
+    public void handling_should_throw_if_cannot_actually_handle() {
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(NO));
+
+        assertThatThrownBy(() -> internalEndAppealLetterWithAttachmentBundleHandler.handle(ABOUT_TO_START, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+
+        when(callback.getEvent()).thenReturn(Event.START_APPEAL);
+
+        assertThatThrownBy(() -> internalEndAppealLetterWithAttachmentBundleHandler.handle(PreSubmitCallbackStage.ABOUT_TO_SUBMIT, callback))
+            .hasMessage("Cannot handle callback")
+            .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    private Document createDocumentWithDescription() {
+        return
+            new Document("some-url",
+                "some-binary-url",
+                RandomStringUtils.randomAlphabetic(20));
+    }
+
+    private DocumentWithMetadata createDocumentWithMetadata() {
+
+        return
+            new DocumentWithMetadata(createDocumentWithDescription(),
+                RandomStringUtils.randomAlphabetic(20),
+                new SystemDateProvider().now().toString(), DocumentTag.INTERNAL_END_APPEAL_LETTER,"test");
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/service/BundleOrderTest.java
@@ -37,7 +37,7 @@ public class BundleOrderTest {
             .map(DocumentWithMetadata::getTag)
             .collect(Collectors.toList());
 
-        assertEquals(77, sortedTags.size());
+        assertEquals(79, sortedTags.size());
 
         List<DocumentTag> documentTagList = Arrays.asList(
             DocumentTag.CASE_SUMMARY,
@@ -116,6 +116,8 @@ public class BundleOrderTest {
             DocumentTag.IAUT_2_FORM,
             DocumentTag.UPDATED_DECISION_AND_REASONS_COVER_LETTER,
             DocumentTag.UPDATED_FINAL_DECISION_AND_REASONS_PDF,
+            DocumentTag.INTERNAL_END_APPEAL_LETTER,
+            DocumentTag.INTERNAL_END_APPEAL_LETTER_BUNDLE,
             DocumentTag.NONE
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalEndAppealLetterTemplateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/templates/letter/InternalEndAppealLetterTemplateTest.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.reform.iacasedocumentsapi.domain.templates.letter;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCase;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.CaseDetails;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.AddressUk;
+import uk.gov.hmcts.reform.iacasedocumentsapi.infrastructure.CustomerServicesProvider;
+
+@MockitoSettings(strictness = Strictness.LENIENT)
+@SuppressWarnings("unchecked")
+@ExtendWith(MockitoExtension.class)
+class InternalEndAppealLetterTemplateTest {
+    @Mock
+    private CaseDetails<AsylumCase> caseDetails;
+    @Mock
+    private AsylumCase asylumCase;
+    @Mock
+    private CustomerServicesProvider customerServicesProvider;
+    @Mock
+    AddressUk address;
+    private final String telephoneNumber = "0300 123 1711";
+    private String appellantGivenNames = "John";
+    private String appellantFamilyName = "Smith";
+    private String homeOfficeReferenceNumber = "123654";
+    private String appealReferenceNumber = "HU/11111/2022";
+    private String appealEndDate = "2023-07-22";
+    private String approverType = "Legal Officer";
+    private final String templateName = "templateName";
+    private final String logo = "[userImage:hmcts.png]";
+    private String addressLine1 = "50";
+    private String addressLine2 = "Building name";
+    private String addressLine3 = "Street name";
+    private String postCode = "XX1 2YY";
+    private String postTown = "Town name";
+    private InternalEndAppealLetterTemplate internalEndAppealLetterTemplate;
+    private Map<String, Object> fieldValuesMap;
+
+    @BeforeEach
+    public void setUp() {
+        internalEndAppealLetterTemplate =
+            new InternalEndAppealLetterTemplate(templateName, customerServicesProvider);
+    }
+
+    @Test
+    void should_return_template_name() {
+        assertEquals(templateName, internalEndAppealLetterTemplate.getName());
+    }
+
+    void dataSetup() {
+        when(caseDetails.getCaseData()).thenReturn(asylumCase);
+        when(customerServicesProvider.getInternalCustomerServicesTelephone(asylumCase)).thenReturn(telephoneNumber);
+        when(asylumCase.read(APPEAL_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(appealReferenceNumber));
+        when(asylumCase.read(APPELLANT_GIVEN_NAMES, String.class)).thenReturn(Optional.of(appellantGivenNames));
+        when(asylumCase.read(APPELLANT_FAMILY_NAME, String.class)).thenReturn(Optional.of(appellantFamilyName));
+        when(asylumCase.read(HOME_OFFICE_REFERENCE_NUMBER, String.class)).thenReturn(Optional.of(homeOfficeReferenceNumber));
+        when(asylumCase.read(END_APPEAL_DATE, String.class)).thenReturn(Optional.of(appealEndDate));
+        when(asylumCase.read(END_APPEAL_APPROVER_TYPE, String.class)).thenReturn(Optional.of(approverType));
+        when(asylumCase.read(APPELLANT_ADDRESS, AddressUk.class)).thenReturn(Optional.of(address));
+        when(address.getAddressLine1()).thenReturn(Optional.of(addressLine1));
+        when(address.getAddressLine2()).thenReturn(Optional.of(addressLine2));
+        when(address.getAddressLine3()).thenReturn(Optional.of(addressLine3));
+        when(address.getPostCode()).thenReturn(Optional.of(postCode));
+        when(address.getPostTown()).thenReturn(Optional.of(postTown));
+    }
+
+    @Test
+    void should_populate_template_correctly() {
+        dataSetup();
+        fieldValuesMap = internalEndAppealLetterTemplate.mapFieldValues(caseDetails);
+        assertEquals(logo, fieldValuesMap.get("hmcts"));
+        assertEquals(appealReferenceNumber, fieldValuesMap.get("appealReferenceNumber"));
+        assertEquals(appellantGivenNames, fieldValuesMap.get("appellantGivenNames"));
+        assertEquals(appellantFamilyName, fieldValuesMap.get("appellantFamilyName"));
+        assertEquals(homeOfficeReferenceNumber, fieldValuesMap.get("homeOfficeReferenceNumber"));
+        assertEquals(telephoneNumber, fieldValuesMap.get("customerServicesTelephone"));
+        assertEquals(LocalDate.now().format(DateTimeFormatter.ofPattern("d MMMM yyyy")), fieldValuesMap.get("dateLetterSent"));
+        assertEquals("22 July 2023", fieldValuesMap.get("endAppealDate"));
+        assertEquals(approverType, fieldValuesMap.get("decisionMaker"));
+        assertEquals(addressLine1, fieldValuesMap.get("address_line_1"));
+        assertEquals(addressLine2, fieldValuesMap.get("address_line_2"));
+        assertEquals(addressLine3, fieldValuesMap.get("address_line_3"));
+        assertEquals(postTown, fieldValuesMap.get("address_line_4"));
+        assertEquals(postCode, fieldValuesMap.get("address_line_5"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/utils/AsylumCaseUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/utils/AsylumCaseUtilsTest.java
@@ -7,6 +7,7 @@ import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumAppea
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.AsylumCaseDefinition.*;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.RemissionType.HO_WAIVER_REMISSION;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.RemissionType.NO_REMISSION;
+import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo.NO;
 import static uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo.YES;
 
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.RequiredFieldMissingException;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.*;
+import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.AddressUk;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.Document;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.IdValue;
 import uk.gov.hmcts.reform.iacasedocumentsapi.domain.entities.ccd.field.YesOrNo;
@@ -39,6 +41,8 @@ public class AsylumCaseUtilsTest {
     private AsylumCase asylumCase;
     @Mock
     private Document document;
+    @Mock
+    private AddressUk address;
     private final String directionExplanation = "some explanation";
     private final Parties directionParties = Parties.APPELLANT;
     private final String directionDateDue = "2023-06-16";
@@ -148,6 +152,14 @@ public class AsylumCaseUtilsTest {
         } else {
             assertFalse(AsylumCaseUtils.isInternalCase(asylumCase));
         }
+    }
+
+    @Test
+    void should_return_true_for_internal_non_detained_case() {
+        when(asylumCase.read(IS_ADMIN, YesOrNo.class)).thenReturn(Optional.of(YES));
+        when(asylumCase.read(APPELLANT_IN_DETENTION, YesOrNo.class)).thenReturn(Optional.of(NO));
+
+        assertTrue(AsylumCaseUtils.isInternalNonDetainedCase(asylumCase));
     }
 
     @Test
@@ -311,6 +323,34 @@ public class AsylumCaseUtilsTest {
         assertThatThrownBy(() -> AsylumCaseUtils.getDirectionDueDateAndExplanation(asylumCase))
                 .isExactlyInstanceOf(IllegalStateException.class)
                 .hasMessage("Direction edit explanation is not present");
+    }
+
+    @Test
+    void should_return_address_with_all_fields_populated() {
+        when(asylumCase.read(AsylumCaseDefinition.APPELLANT_ADDRESS, AddressUk.class)).thenReturn(Optional.of(address));
+        when(address.getAddressLine1()).thenReturn(Optional.of("Apartment 99"));
+        when(address.getAddressLine2()).thenReturn(Optional.of("Example Road"));
+        when(address.getAddressLine3()).thenReturn(Optional.of("Example County"));
+        when(address.getPostTown()).thenReturn(Optional.of("Example Town"));
+        when(address.getPostCode()).thenReturn(Optional.of("PostCode"));
+
+        List<String> result = AsylumCaseUtils.getAppellantAddressAsList(asylumCase);
+
+        assertEquals(5, result.size());
+        assertEquals("Apartment 99", result.get(0));
+        assertEquals("Example Road", result.get(1));
+        assertEquals("Example County", result.get(2));
+        assertEquals("Example Town", result.get(3));
+        assertEquals("PostCode", result.get(4));
+    }
+
+    @Test
+    void should_throw_when_address_is_not_present() {
+        when(asylumCase.read(AsylumCaseDefinition.APPELLANT_ADDRESS, AddressUk.class)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalStateException.class, () -> {
+            AsylumCaseUtils.getAppellantAddressAsList(asylumCase);
+        }, "appellantAddress is not present");
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/enties/em/BundleTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/infrastructure/enties/em/BundleTest.java
@@ -83,6 +83,24 @@ public class BundleTest {
     }
 
     @Test
+    public void shouldConvertNullValuesToOptionalEmptyCoverSheetContentsConstructor() {
+        bundle = new Bundle(
+            id,
+            title,
+            description,
+            eligibleForStitching,
+            documents,
+            hasCoversheets,
+            hasTableOfContents,
+            filename
+        );
+
+        assertEquals(bundle.getStitchStatus(), Optional.empty());
+        assertEquals(bundle.getStitchedDocument(), Optional.empty());
+
+    }
+
+    @Test
     public void shouldConvertNullValuesToOptionalEmptyWhenUsingEmptyConstructor() throws Exception {
 
         bundle = findPrivateNoArgsConstructor(Bundle.class).newInstance();


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/RIA-8337

### Change description ###

- internalEndAppealLetter document generated + stored in LETTER_NOTIFICATION_DOCUMENTS
- notice of ended appeal being stored in LETTER_NOTIFICATION_DOCUMENTS (already generated and stored in TRIBUNAL_DOCUMENTS)
- internalEndAppealLetterWithAttachment bundled and stored in LETTER_BUNDLE_DOCUMENTS
- LETTER_NOTIFICATION_DOCUMENTS cleared after bundling

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [X] Does this PR introduce a breaking change
