### PR TITLE
RIA-9143 Update the customise hearing bundle to include documents fro…

### DIFF
--- a/src/functionalTest/resources/scenarios/RIA-3130-finalBundling-to-preHearing.json
+++ b/src/functionalTest/resources/scenarios/RIA-3130-finalBundling-to-preHearing.json
@@ -184,6 +184,28 @@
     "caseData": {
       "template": "minimal-appeal-submitted.json",
       "replacements": {
+        "reheardHearingDocumentsCollection": [
+          {
+            "id": "1",
+            "value": {
+              "reheardHearingDocs": [
+                {
+                  "id": "1",
+                  "value": {
+                    "tag": "reheardHearingNotice",
+                    "document": {
+                      "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                      "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                      "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                    },
+                    "description": "",
+                    "dateUploaded": "{$TODAY}"
+                  }
+                }
+              ]
+            }
+          }
+        ],
         "additionalEvidenceDocuments": [
           {
             "id": "2",
@@ -300,21 +322,6 @@
               "description": "",
               "dateUploaded": "{$TODAY}",
               "tag": "ftpaDecisionAndReasons"
-            }
-          }
-        ],
-        "reheardHearingDocuments": [
-          {
-            "id": "1",
-            "value": {
-              "document": {
-                "document_url": "{$FIXTURE_DOC1_PDF_URL}",
-                "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
-                "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
-              },
-              "description": "",
-              "dateUploaded": "{$TODAY}",
-              "tag": "reheardHearingNotice"
             }
           }
         ],

--- a/src/functionalTest/resources/scenarios/RIA-8291-generate-hearing-bundle-remitted.json
+++ b/src/functionalTest/resources/scenarios/RIA-8291-generate-hearing-bundle-remitted.json
@@ -1,5 +1,5 @@
 {
-  "description": "RIA-3130-generate-hearing-generic-bundle",
+  "description": "RIA-8291-generate-hearing-generic-bundle",
   "enabled": "{$featureFlag.isEmStitchingEnabled}",
   "launchDarklyKey": "dlrm-remitted-feature-flag:true",
   "request": {

--- a/src/functionalTest/resources/scenarios/RIA-9143-customise-reheard-hearing-bundle-with-remitted-preparer.json
+++ b/src/functionalTest/resources/scenarios/RIA-9143-customise-reheard-hearing-bundle-with-remitted-preparer.json
@@ -1,0 +1,340 @@
+{
+  "description": "RIA-9143-customise-reheard-hearing-bundle-preparer-reheard-hearing documents are present in reheardHearingDocuments & reheardHearingDocumentsCollection",
+  "launchDarklyKey": "reheard-feature:true",
+  "launchDarklyKey": "dlrm-remitted-feature-flag:true",
+  "request": {
+    "uri": "/asylum/ccdAboutToStart",
+    "credentials": "CaseOfficer",
+    "input": {
+      "eventId": "customiseHearingBundle",
+      "state": "preHearing",
+      "caseData": {
+        "template": "minimal-appeal-submitted.json",
+        "replacements": {
+          "caseFlagSetAsideReheardExists": "Yes",
+          "listCaseHearingCentre": "taylorHouse",
+          "ariaListingReference": "LP/12345/2019",
+          "legalRepReferenceNumber": "REF54321",
+          "sourceOfRemittal": "Court of Appeal",
+          "ftpaAppellantDocuments": [
+            {
+              "id": "2",
+              "value": {
+                "document": {
+                  "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+                },
+                "description": "",
+                "dateUploaded": "{$TODAY}",
+                "tag": "ftpaAppellant"
+              }
+            },
+            {
+              "id": "1",
+              "value": {
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "description": "",
+                "dateUploaded": "{$TODAY}",
+                "tag": "ftpaAppellant"
+              }
+            }
+          ],
+          "finalDecisionAndReasonsDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "document": {
+                  "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+                },
+                "description": "",
+                "dateUploaded": "{$TODAY}",
+                "tag": "finalDecisionAndReasonsPdf"
+              }
+            }
+          ],
+          "addendumEvidenceDocuments": [
+            {
+              "id": "2",
+              "value": {
+                "document": {
+                  "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+                },
+                "description": "",
+                "dateUploaded": "{$TODAY}",
+                "tag": "addendumEvidence",
+                "suppliedBy": "The respondent"
+              }
+            },
+            {
+              "id": "1",
+              "value": {
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "description": "",
+                "dateUploaded": "{$TODAY}",
+                "tag": "addendumEvidence",
+                "suppliedBy": "The appellant"
+              }
+            }
+          ],
+          "remittalDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "decisionDocument": {
+                  "tag": "remittalDecision",
+                  "document": {
+                    "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                    "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                    "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                  },
+                  "description": "",
+                  "dateUploaded": "{$TODAY}"
+                },
+                "otherRemittalDocs": [
+                  {
+                    "id": "11",
+                    "value": {
+                      "tag": "remittalDecision",
+                      "document": {
+                        "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                        "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                        "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+                      },
+                      "description": "test",
+                      "dateUploaded": "{$TODAY}"
+                    }
+                  }
+                ]
+              }
+            }
+          ],
+          "reheardHearingDocuments": [
+            {
+              "id": "1",
+              "value": {
+                "tag": "reheardHearingNotice",
+                "document": {
+                  "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                  "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                  "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                },
+                "description": " ",
+                "dateUploaded": "{$TODAY}"
+              }
+            }
+          ],
+          "reheardHearingDocumentsCollection": [
+            {
+              "id": "1",
+              "value": {
+                "reheardHearingDocs": [
+                  {
+                    "id": "2",
+                    "value": {
+                      "document": {
+                        "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                        "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                        "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+                      },
+                      "description": "Case summary",
+                      "dateUploaded": "{$TODAY}",
+                      "tag": "caseSummary"
+                    }
+                  },
+                  {
+                    "id": "1",
+                    "value": {
+                      "document": {
+                        "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                        "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                        "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+                      },
+                      "description": "",
+                      "dateUploaded": "{$TODAY}",
+                      "tag": "reheardHearingNotice",
+                      "suppliedBy": ""
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "expectation": {
+    "status": 200,
+    "errors": [],
+    "caseData": {
+      "template": "minimal-appeal-submitted.json",
+      "replacements": {
+        "customFtpaAppellantDocs": [
+          {
+            "id": "2",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+              },
+              "description": ""
+            }
+          },
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+              },
+              "description": ""
+            }
+          }
+        ],
+        "customFinalDecisionAndReasonsDocs": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+              },
+              "description": ""
+            }
+          }
+        ],
+        "customAppAddendumEvidenceDocs": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+              },
+              "description": ""
+            }
+          }
+        ],
+        "customRespAddendumEvidenceDocs": [
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+              },
+              "description": ""
+            }
+          }
+        ],
+        "customReheardHearingDocs": [
+          {
+            "id": "3",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+              },
+              "description": "Case summary"
+            }
+          },
+          {
+            "id": "2",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+              },
+              "description": ""
+            }
+          },
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+              },
+              "description": " "
+            }
+          }
+        ],
+        "customLatestRemittalDocs": [
+          {
+            "id": "2",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+              },
+              "description": ""
+            }
+          },
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+              },
+              "description": "test"
+            }
+          }
+        ],
+        "addendumEvidenceDocuments": [
+          {
+            "id": "2",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC2_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC2_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC2_PDF_FILENAME}"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "addendumEvidence",
+              "suppliedBy": "The respondent"
+            }
+          },
+          {
+            "id": "1",
+            "value": {
+              "document": {
+                "document_url": "{$FIXTURE_DOC1_PDF_URL}",
+                "document_binary_url": "{$FIXTURE_DOC1_PDF_URL_BINARY}",
+                "document_filename": "{$FIXTURE_DOC1_PDF_FILENAME}"
+              },
+              "description": "",
+              "dateUploaded": "{$TODAY}",
+              "tag": "addendumEvidence",
+              "suppliedBy": "The appellant"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/CustomiseHearingBundlePreparerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/iacasedocumentsapi/domain/handlers/presubmit/CustomiseHearingBundlePreparerTest.java
@@ -190,12 +190,14 @@ class CustomiseHearingBundlePreparerTest {
 
         customiseHearingBundlePreparer.handle(PreSubmitCallbackStage.ABOUT_TO_START, callback);
 
-        verify(asylumCase).write(CUSTOM_REHEARD_HEARING_DOCS, customDocumentList);
+        verify(asylumCase, times(1)).read(REHEARD_HEARING_DOCUMENTS_COLLECTION);
+        verify(asylumCase, times(3)).read(REHEARD_HEARING_DOCUMENTS);
+        verify(asylumCase, times(2)).write(CUSTOM_REHEARD_HEARING_DOCS, customDocumentList);
         verify(asylumCase).write(CUSTOM_APP_ADDITIONAL_EVIDENCE_DOCS, customDocumentList);
         verify(asylumCase).write(CUSTOM_RESP_ADDITIONAL_EVIDENCE_DOCS, customDocumentList);
         verify(asylumCase).write(CUSTOM_FTPA_APPELLANT_DOCS, customDocumentList);
         verify(asylumCase).write(CUSTOM_FTPA_RESPONDENT_DOCS, customDocumentList);
-        verify(asylumCase).write(CUSTOM_FINAL_DECISION_AND_REASONS_DOCS, customDocumentList);
+        verify(asylumCase, times(2)).write(CUSTOM_FINAL_DECISION_AND_REASONS_DOCS, customDocumentList);
         verify(asylumCase).write(CUSTOM_APP_ADDENDUM_EVIDENCE_DOCS, customDocumentList);
         verify(asylumCase,times(1)).write(AsylumCaseDefinition.CUSTOM_RESP_ADDENDUM_EVIDENCE_DOCS,customDocumentList);
         verify(asylumCase,times(4)).read(AsylumCaseDefinition.ADDENDUM_EVIDENCE_DOCUMENTS);


### PR DESCRIPTION
…m both reheardHearingDocuments & reheardHearingDocumentsCollection

- In scenarios where the reheard documents are present in both the fields, preparer will take them all and add to custom collection.
- After bundling, the undpated list will be stored in the reheardHearingDocumentsCollection.
- reheardHearingDocuments will not be updated with any new changes in the list.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
