### PR TITLE
DIAC-1021 update fortify lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@
 /dist/
 /nbdist/
 /.nb-gradle/
+
+### vs ###
+/bin/*
+!/bin/*.sh
+.vscode 

--- a/build.gradle
+++ b/build.gradle
@@ -382,7 +382,7 @@ dependencies {
 
     testImplementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
 
-    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.8', classifier: 'all', {
+    testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.4.9', classifier: 'all', {
         exclude group: 'commons-io', module: 'commons-io'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
     }


### PR DESCRIPTION
Update fortify lib from 1.4.8 to 1.4.9 because 1.4.8 is not available for download anymore


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x ] No


